### PR TITLE
Add policy support for creating / deleting warrants

### DIFF
--- a/src/modules/Authorization.ts
+++ b/src/modules/Authorization.ts
@@ -1,6 +1,6 @@
 import Feature from "./Feature";
 import Permission from "./Permission";
-import Check, { AccessCheckRequest, CheckMany, FeatureCheck, PermissionCheck } from "../types/Check";
+import Check, { AccessCheckRequest, CheckMany, CheckWarrantRequest, FeatureCheck, PermissionCheck } from "../types/Check";
 import Warrant, { isSubject, isWarrantObject } from "../types/Warrant";
 import WarrantClient from "../WarrantClient";
 
@@ -24,7 +24,7 @@ export default class Authorization {
     }
 
     public static async checkMany(check: CheckMany): Promise<boolean> {
-        let warrants: Warrant[] = check.warrants.map((warrant) => {
+        let warrants: CheckWarrantRequest[] = check.warrants.map((warrant) => {
             return {
                 objectType: isWarrantObject(warrant.object) ? warrant.object.getObjectType() : warrant.object.objectType,
                 objectId: isWarrantObject(warrant.object) ? warrant.object.getObjectId() : warrant.object.objectId,

--- a/src/modules/Authorization.ts
+++ b/src/modules/Authorization.ts
@@ -14,7 +14,6 @@ export default class Authorization {
                 subject: isSubject(check.subject) ? check.subject : { objectType: check.subject.getObjectType(), objectId: check.subject.getObjectId() },
                 context: check.context
             }],
-            consistentRead: check.consistentRead,
             debug: check.debug
         }
         if (WarrantClient.config.authorizeEndpoint) {
@@ -37,7 +36,6 @@ export default class Authorization {
         const accessCheckRequest: AccessCheckRequest = {
             op: check.op,
             warrants: warrants,
-            consistentRead: check.consistentRead,
             debug: check.debug
         }
 
@@ -54,7 +52,6 @@ export default class Authorization {
             relation: "member",
             subject: featureCheck.subject,
             context: featureCheck.context,
-            consistentRead: featureCheck.consistentRead,
             debug: featureCheck.debug
         })
     }
@@ -65,7 +62,6 @@ export default class Authorization {
             relation: "member",
             subject: permissionCheck.subject,
             context: permissionCheck.context,
-            consistentRead: permissionCheck.consistentRead,
             debug: permissionCheck.debug
         })
     }

--- a/src/modules/PricingTier.ts
+++ b/src/modules/PricingTier.ts
@@ -5,7 +5,7 @@ import WarrantClient from "../WarrantClient";
 import { ListFeatureOptions } from "../types/Feature";
 import { ObjectType } from "../types/ObjectType";
 import { CreatePricingTierParams, ListPricingTierOptions } from "../types/PricingTier";
-import Warrant, { Context, WarrantObject } from "../types/Warrant";
+import Warrant, { PolicyContext, WarrantObject } from "../types/Warrant";
 
 export default class PricingTier implements WarrantObject {
     pricingTierId: string;
@@ -160,7 +160,7 @@ export default class PricingTier implements WarrantObject {
         return Feature.removeFeatureFromPricingTier(this.pricingTierId, featureId);
     }
 
-    public async hasFeature(featureId: string, context: Context = {}): Promise<boolean> {
+    public async hasFeature(featureId: string, context: PolicyContext = {}): Promise<boolean> {
         return Authorization.hasFeature({ featureId: featureId, subject: { objectType: ObjectType.PricingTier, objectId: this.pricingTierId }, context: context });
     }
 

--- a/src/modules/Role.ts
+++ b/src/modules/Role.ts
@@ -5,7 +5,7 @@ import WarrantClient from "../WarrantClient";
 import { ObjectType } from "../types/ObjectType";
 import { ListPermissionOptions } from "../types/Permission";
 import { CreateRoleParams, ListRoleOptions, UpdateRoleParams } from "../types/Role";
-import Warrant, { Context, WarrantObject } from "../types/Warrant";
+import Warrant, { PolicyContext, WarrantObject } from "../types/Warrant";
 
 export default class Role implements WarrantObject {
     roleId: string;
@@ -136,7 +136,7 @@ export default class Role implements WarrantObject {
         return Permission.removePermissionFromRole(this.roleId, permissionId);
     }
 
-    public async hasPermission(permissionId: string, context: Context = {}): Promise<boolean> {
+    public async hasPermission(permissionId: string, context: PolicyContext = {}): Promise<boolean> {
         return Authorization.hasPermission({ permissionId: permissionId, subject: { objectType: ObjectType.Role, objectId: this.roleId }, context: context });
     }
 

--- a/src/modules/Tenant.ts
+++ b/src/modules/Tenant.ts
@@ -9,7 +9,7 @@ import { ObjectType } from "../types/ObjectType";
 import { ListPricingTierOptions } from "../types/PricingTier";
 import { CreateTenantParams, ListTenantOptions, UpdateTenantParams } from "../types/Tenant";
 import { ListUserOptions } from "../types/User";
-import { Context, WarrantObject } from "../types/Warrant";
+import { PolicyContext, WarrantObject } from "../types/Warrant";
 
 export default class Tenant implements WarrantObject {
     // Tenant properties
@@ -150,7 +150,7 @@ export default class Tenant implements WarrantObject {
         return Feature.removeFeatureFromTenant(this.tenantId, featureId);
     }
 
-    public async hasFeature(featureId: string, context: Context = {}): Promise<boolean> {
+    public async hasFeature(featureId: string, context: PolicyContext = {}): Promise<boolean> {
         return Authorization.hasFeature({ featureId: featureId, subject: { objectType: ObjectType.Tenant, objectId: this.tenantId }, context: context });
     }
 

--- a/src/modules/User.ts
+++ b/src/modules/User.ts
@@ -13,7 +13,7 @@ import { ListPricingTierOptions } from "../types/PricingTier";
 import { ListRoleOptions } from "../types/Role";
 import { CreateUserParams, ListUserOptions, UpdateUserParams } from "../types/User";
 import { ListTenantOptions } from "../types/Tenant";
-import { Context, WarrantObject } from "../types/Warrant";
+import { PolicyContext, WarrantObject } from "../types/Warrant";
 import WarrantModule from "./WarrantModule";
 
 export default class User implements WarrantObject {
@@ -174,7 +174,7 @@ export default class User implements WarrantObject {
         return Permission.removePermissionFromUser(this.userId, permissionId);
     }
 
-    public async hasPermission(permissionId: string, context: Context = {}): Promise<boolean> {
+    public async hasPermission(permissionId: string, context: PolicyContext = {}): Promise<boolean> {
         return Authorization.hasPermission({ permissionId: permissionId, subject: { objectType: ObjectType.User, objectId: this.userId }, context: context });
     }
 
@@ -202,7 +202,7 @@ export default class User implements WarrantObject {
         return Feature.removeFeatureFromUser(this.userId, featureId);
     }
 
-    public async hasFeature(featureId: string, context: Context = {}): Promise<boolean> {
+    public async hasFeature(featureId: string, context: PolicyContext = {}): Promise<boolean> {
         return Authorization.hasFeature({ featureId: featureId, subject: { objectType: ObjectType.User, objectId: this.userId }, context: context });
     }
 

--- a/src/modules/WarrantModule.ts
+++ b/src/modules/WarrantModule.ts
@@ -12,7 +12,7 @@ export default class WarrantModule {
                     objectId: isWarrantObject(warrant.object) ? warrant.object.getObjectId() : warrant.object.objectId,
                     relation: warrant.relation,
                     subject: isSubject(warrant.subject) ? warrant.subject : { objectType: warrant.subject.getObjectType(), objectId: warrant.subject.getObjectId() },
-                    context: warrant.context
+                    policy: warrant.policy
                 },
             });
         } catch (e) {
@@ -29,7 +29,7 @@ export default class WarrantModule {
                     objectId: isWarrantObject(warrant.object) ? warrant.object.getObjectId() : warrant.object.objectId,
                     relation: warrant.relation,
                     subject: isSubject(warrant.subject) ? warrant.subject : { objectType: warrant.subject.getObjectType(), objectId: warrant.subject.getObjectId() },
-                    context: warrant.context
+                    policy: warrant.policy
                 },
             });
         } catch (e) {

--- a/src/types/Check.ts
+++ b/src/types/Check.ts
@@ -36,16 +36,8 @@ export interface PermissionCheck {
     debug?: boolean;
 }
 
-export interface CheckWarrantRequest {
-    objectType: string;
-    objectId: string;
-    relation: string;
-    subject: WarrantObject | Subject;
-    context?: PolicyContext;
-}
-
 export interface AccessCheckRequest {
     op?: CheckOp;
-    warrants: CheckWarrantRequest[];
+    warrants: CheckWarrant[];
     debug?: boolean;
 }

--- a/src/types/Check.ts
+++ b/src/types/Check.ts
@@ -1,4 +1,4 @@
-import Warrant, { Context, Subject, WarrantObject, WarrantObjectLiteral } from "./Warrant";
+import Warrant, { PolicyContext, Subject, WarrantObject, WarrantObjectLiteral } from "./Warrant";
 
 export enum CheckOp {
     AllOf = "allOf",
@@ -9,7 +9,7 @@ export interface CheckWarrant {
     object: WarrantObject | WarrantObjectLiteral;
     relation: string;
     subject: WarrantObject | Subject;
-    context?: Context;
+    context?: PolicyContext;
 }
 
 export default interface Check extends CheckWarrant {
@@ -25,19 +25,27 @@ export interface CheckMany {
 export interface FeatureCheck {
     featureId: string;
     subject: WarrantObject | Subject;
-    context?: Context;
+    context?: PolicyContext;
     debug?: boolean;
 }
 
 export interface PermissionCheck {
     permissionId: string;
     subject: WarrantObject | Subject;
-    context?: Context;
+    context?: PolicyContext;
     debug?: boolean;
+}
+
+export interface CheckWarrantRequest {
+    objectType: string;
+    objectId: string;
+    relation: string;
+    subject: WarrantObject | Subject;
+    context?: PolicyContext;
 }
 
 export interface AccessCheckRequest {
     op?: CheckOp;
-    warrants: Warrant[];
+    warrants: CheckWarrantRequest[];
     debug?: boolean;
 }

--- a/src/types/Check.ts
+++ b/src/types/Check.ts
@@ -13,14 +13,12 @@ export interface CheckWarrant {
 }
 
 export default interface Check extends CheckWarrant {
-    consistentRead?: boolean;
     debug?: boolean;
 }
 
 export interface CheckMany {
     op?: CheckOp;
     warrants: CheckWarrant[];
-    consistentRead?: boolean;
     debug?: boolean;
 }
 
@@ -28,7 +26,6 @@ export interface FeatureCheck {
     featureId: string;
     subject: WarrantObject | Subject;
     context?: Context;
-    consistentRead?: boolean;
     debug?: boolean;
 }
 
@@ -36,13 +33,11 @@ export interface PermissionCheck {
     permissionId: string;
     subject: WarrantObject | Subject;
     context?: Context;
-    consistentRead?: boolean;
     debug?: boolean;
 }
 
 export interface AccessCheckRequest {
     op?: CheckOp;
     warrants: Warrant[];
-    consistentRead?: boolean;
     debug?: boolean;
 }

--- a/src/types/Query.ts
+++ b/src/types/Query.ts
@@ -1,17 +1,17 @@
-import { Context, isSubject, isWarrantObject, Subject, WarrantObject, WarrantObjectLiteral } from "./Warrant";
+import { isSubject, isWarrantObject, PolicyContext, Subject, WarrantObject, WarrantObjectLiteral } from "./Warrant";
 
 export interface ForClause {
     object?: WarrantObject | WarrantObjectLiteral;
     relation?: string;
     subject?: Subject | WarrantObject;
-    context?: Context;
+    context?: PolicyContext;
 }
 
 export interface WhereClause {
     object?: WarrantObject | WarrantObjectLiteral;
     relation?: string;
     subject?: Subject | WarrantObject;
-    context?: Context;
+    context?: PolicyContext;
 }
 
 export default class Query {

--- a/src/types/Session.ts
+++ b/src/types/Session.ts
@@ -1,9 +1,9 @@
-import { Context } from "./Warrant";
+import { PolicyContext } from "./Warrant";
 
 export interface SessionParams {
     userId: string;
     ttl?: number;
-    context?: Context;
+    context?: PolicyContext;
 }
 
 export interface SelfServiceSessionParams extends SessionParams {

--- a/src/types/Warrant.ts
+++ b/src/types/Warrant.ts
@@ -7,8 +7,8 @@ export interface ListWarrantOptions extends ListOptions {
     userId?: string;
 }
 
-export interface Context {
-    [key: string]: string;
+export interface PolicyContext {
+    [key: string]: any;
 }
 
 export interface Subject {
@@ -27,7 +27,7 @@ export default interface Warrant {
     objectId: string;
     relation: string;
     subject: Subject;
-    context?: Context;
+    policy?: string;
 }
 
 export interface WarrantObject {
@@ -48,5 +48,5 @@ export interface WarrantParams {
     object: WarrantObject | WarrantObjectLiteral;
     relation: string;
     subject: WarrantObject | Subject;
-    context?: Context;
+    policy?: string;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,5 +8,5 @@ export { CreateRoleParams, ListRoleOptions, UpdateRoleParams } from "./Role";
 export { SessionParams, SelfServiceSessionParams, SelfServiceStrategy } from "./Session";
 export { CreateTenantParams, ListTenantOptions, UpdateTenantParams } from "./Tenant";
 export { CreateUserParams, ListUserOptions, UpdateUserParams } from "./User";
-export { default as Warrant, ListWarrantOptions, Context, Subject, WarrantObject } from "./Warrant";
+export { default as Warrant, ListWarrantOptions, PolicyContext, Subject, WarrantObject } from "./Warrant";
 export { default as Check, CheckMany, CheckOp, CheckWarrant, FeatureCheck, PermissionCheck } from "./Check";

--- a/test/LiveTest.spec.js
+++ b/test/LiveTest.spec.js
@@ -536,4 +536,64 @@ describe.skip('Live Test', function () {
         await this.warrant.User.delete(newUser.userId);
         await this.warrant.Permission.delete(newPermission.permissionId);
     });
+
+    it('warrant with policy', async function() {
+        await this.warrant.Warrant.create({
+            object: {
+                objectType: "permission",
+                objectId: "test-permission"
+            },
+            relation: "member",
+            subject: {
+                objectType: "user",
+                objectId: "user-1"
+            },
+            policy: `geo == "us"`
+        });
+
+        checkResult = await this.warrant.Authorization.check({
+            object: {
+                objectType: "permission",
+                objectId: "test-permission"
+            },
+            relation: "member",
+            subject: {
+                objectType: "user",
+                objectId: "user-1"
+            },
+            context: {
+                "geo": "us",
+            }
+        });
+        assert.strictEqual(checkResult, true);
+
+        checkResult = await this.warrant.Authorization.check({
+            object: {
+                objectType: "permission",
+                objectId: "test-permission"
+            },
+            relation: "member",
+            subject: {
+                objectType: "user",
+                objectId: "user-1"
+            },
+            context: {
+                "geo": "eu",
+            }
+        });
+        assert.strictEqual(checkResult, false);
+
+        await this.warrant.Warrant.delete({
+            object: {
+                objectType: "permission",
+                objectId: "test-permission"
+            },
+            relation: "member",
+            subject: {
+                objectType: "user",
+                objectId: "user-1"
+            },
+            policy: `geo == "us"`
+        });
+    });
 })


### PR DESCRIPTION
This PR adds support for creating and deleting warrants with a policy.

```
try {
        await this.warrant.Warrant.create({
                object: {
                        objectType: "permission",
                        objectId: "view-items",
                },
                relation: "member",
                subject: {
                        objectType: "user",
                        objectId: "user-1",
                },
                policy: `geo == "us"`
        });   
} catch (e) {
        // handle error
}
```

```
try {
        await this.warrant.Warrant.delete({
                object: {
                        objectType: "permission",
                        objectId: "view-items",
                },
                relation: "member",
                subject: {
                        objectType: "user",
                        objectId: "user-1",
                },
                policy: `geo == "us"`
        });   
} catch (e) {
        // handle error
}
```
