### PR TITLE
Add warrant token support

### DIFF
--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -1,4 +1,5 @@
 import ApiError from "./types/ApiError";
+import { UserRequestOptions } from "./types/Params";
 
 const { version } = require("../package.json");
 
@@ -20,6 +21,7 @@ export interface HttpClientRequestOptions {
     data?: any;
     params?: any;
     url: string;
+    options?: UserRequestOptions;
 }
 
 interface RequestHeaders {
@@ -105,6 +107,10 @@ export default class ApiClient implements HttpClient {
 
         if (requestOptions?.baseUrl) {
             baseUrl = requestOptions.baseUrl;
+        }
+
+        if (requestOptions?.options?.warrantToken) {
+            fetchRequestOptions.headers['Warrant-Token'] = requestOptions.options.warrantToken;
         }
 
         let requestUrl = `${baseUrl}${requestOptions.url}`;

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -1,5 +1,5 @@
 import ApiError from "./types/ApiError";
-import { UserRequestOptions } from "./types/Params";
+import { WarrantRequestOptions } from "./types/WarrantRequestOptions";
 
 const { version } = require("../package.json");
 
@@ -21,7 +21,7 @@ export interface HttpClientRequestOptions {
     data?: any;
     params?: any;
     url: string;
-    options?: UserRequestOptions;
+    options?: WarrantRequestOptions;
 }
 
 interface RequestHeaders {

--- a/src/modules/Authorization.ts
+++ b/src/modules/Authorization.ts
@@ -1,12 +1,12 @@
 import Feature from "./Feature";
 import Permission from "./Permission";
 import Check, { AccessCheckRequest, CheckMany, CheckWarrant, FeatureCheck, PermissionCheck } from "../types/Check";
-import { UserRequestOptions } from "../types/Params";
+import { WarrantRequestOptions } from "../types/WarrantRequestOptions";
 import Warrant, { isSubject, isWarrantObject } from "../types/Warrant";
 import WarrantClient from "../WarrantClient";
 
 export default class Authorization {
-    public static async check(check: Check, options: UserRequestOptions = {}): Promise<boolean> {
+    public static async check(check: Check, options: WarrantRequestOptions = {}): Promise<boolean> {
         const accessCheckRequest: AccessCheckRequest = {
             warrants: [{
                 object: check.object,
@@ -23,7 +23,7 @@ export default class Authorization {
         return this.authorize(accessCheckRequest, options);
     }
 
-    public static async checkMany(check: CheckMany, options: UserRequestOptions = {}): Promise<boolean> {
+    public static async checkMany(check: CheckMany, options: WarrantRequestOptions = {}): Promise<boolean> {
         let warrants: CheckWarrant[] = check.warrants.map((warrant) => {
             return {
                 object: warrant.object,
@@ -45,7 +45,7 @@ export default class Authorization {
         return this.authorize(accessCheckRequest, options);
     }
 
-    public static async hasFeature(featureCheck: FeatureCheck, options: UserRequestOptions = {}): Promise<boolean> {
+    public static async hasFeature(featureCheck: FeatureCheck, options: WarrantRequestOptions = {}): Promise<boolean> {
         return this.check({
             object: new Feature(featureCheck.featureId),
             relation: "member",
@@ -55,7 +55,7 @@ export default class Authorization {
         }, options)
     }
 
-    public static async hasPermission(permissionCheck: PermissionCheck, options: UserRequestOptions = {}): Promise<boolean> {
+    public static async hasPermission(permissionCheck: PermissionCheck, options: WarrantRequestOptions = {}): Promise<boolean> {
         return this.check({
             object: new Permission(permissionCheck.permissionId),
             relation: "member",
@@ -66,7 +66,7 @@ export default class Authorization {
     }
 
     // Private methods
-    private static async authorize(accessCheckRequest: AccessCheckRequest, options: UserRequestOptions = {}): Promise<boolean> {
+    private static async authorize(accessCheckRequest: AccessCheckRequest, options: WarrantRequestOptions = {}): Promise<boolean> {
         try {
 
             const response = await WarrantClient.httpClient.post({
@@ -84,7 +84,7 @@ export default class Authorization {
         }
     }
 
-    private static async edgeAuthorize(accessCheckRequest: AccessCheckRequest, options: UserRequestOptions = {}): Promise<boolean> {
+    private static async edgeAuthorize(accessCheckRequest: AccessCheckRequest, options: WarrantRequestOptions = {}): Promise<boolean> {
         try {
             const response = await WarrantClient.httpClient.post({
                 baseUrl: WarrantClient.config.authorizeEndpoint,

--- a/src/modules/Feature.ts
+++ b/src/modules/Feature.ts
@@ -1,6 +1,7 @@
 import WarrantModule from "./WarrantModule";
 import WarrantClient from "../WarrantClient";
 import { CreateFeatureParams, ListFeatureOptions } from "../types/Feature";
+import { UserRequestOptions } from "../types/Params";
 import Warrant, { WarrantObject } from "../types/Warrant";
 import { ObjectType } from "../types/ObjectType";
 
@@ -14,11 +15,12 @@ export default class Feature implements WarrantObject {
     //
     // Static methods
     //
-    public static async create(feature: CreateFeatureParams): Promise<Feature> {
+    public static async create(feature: CreateFeatureParams, options: UserRequestOptions = {}): Promise<Feature> {
         try {
             const response = await WarrantClient.httpClient.post({
                 url: "/v1/features",
                 data: feature,
+                options,
             });
 
             return new Feature(response.featureId);
@@ -27,10 +29,11 @@ export default class Feature implements WarrantObject {
         }
     }
 
-    public static async get(featureId: string): Promise<Feature> {
+    public static async get(featureId: string, options: UserRequestOptions = {}): Promise<Feature> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/features/${featureId}`,
+                options,
             });
 
             return new Feature(response.featureId);
@@ -39,21 +42,23 @@ export default class Feature implements WarrantObject {
         }
     }
 
-    public static async delete(featureId: string): Promise<void> {
+    public static async delete(featureId: string, options: UserRequestOptions = {}): Promise<void> {
         try {
             return await WarrantClient.httpClient.delete({
                 url: `/v1/features/${featureId}`,
+                options,
             });
         } catch (e) {
             throw e;
         }
     }
 
-    public static async listFeatures(listOptions: ListFeatureOptions = {}): Promise<Feature[]> {
+    public static async listFeatures(listOptions: ListFeatureOptions = {}, options: UserRequestOptions = {}): Promise<Feature[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: "/v1/features",
                 params: listOptions,
+                options,
             });
 
             return response.map((feature: Feature) => new Feature(feature.featureId));
@@ -62,11 +67,12 @@ export default class Feature implements WarrantObject {
         }
     }
 
-    public static async listFeaturesForPricingTier(pricingTierId: string, listOptions: ListFeatureOptions = {}): Promise<Feature[]> {
+    public static async listFeaturesForPricingTier(pricingTierId: string, listOptions: ListFeatureOptions = {}, options: UserRequestOptions = {}): Promise<Feature[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/pricing-tiers/${pricingTierId}/features`,
                 params: listOptions,
+                options,
             });
 
             return response.map((feature: Feature) => new Feature(feature.featureId));
@@ -75,7 +81,7 @@ export default class Feature implements WarrantObject {
         }
     }
 
-    public static async assignFeatureToPricingTier(pricingTierId: string, featureId: string): Promise<Warrant> {
+    public static async assignFeatureToPricingTier(pricingTierId: string, featureId: string, options: UserRequestOptions = {}): Promise<Warrant> {
         return WarrantModule.create({
             object: {
                 objectType: ObjectType.Feature,
@@ -86,10 +92,10 @@ export default class Feature implements WarrantObject {
                 objectType: ObjectType.PricingTier,
                 objectId: pricingTierId,
             }
-        });
+        }, options);
     }
 
-    public static async removeFeatureFromPricingTier(pricingTierId: string, featureId: string): Promise<void> {
+    public static async removeFeatureFromPricingTier(pricingTierId: string, featureId: string, options: UserRequestOptions = {}): Promise<void> {
         return WarrantModule.delete({
             object: {
                 objectType: ObjectType.Feature,
@@ -100,14 +106,15 @@ export default class Feature implements WarrantObject {
                 objectType: ObjectType.PricingTier,
                 objectId: pricingTierId,
             }
-        });
+        }, options);
     }
 
-    public static async listFeaturesForTenant(tenantId: string, listOptions: ListFeatureOptions = {}): Promise<Feature[]> {
+    public static async listFeaturesForTenant(tenantId: string, listOptions: ListFeatureOptions = {}, options: UserRequestOptions = {}): Promise<Feature[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/tenants/${tenantId}/features`,
                 params: listOptions,
+                options,
             });
 
             return response.map((feature: Feature) => new Feature(feature.featureId));
@@ -116,7 +123,7 @@ export default class Feature implements WarrantObject {
         }
     }
 
-    public static async assignFeatureToTenant(tenantId: string, featureId: string): Promise<Warrant> {
+    public static async assignFeatureToTenant(tenantId: string, featureId: string, options: UserRequestOptions = {}): Promise<Warrant> {
         return WarrantModule.create({
             object: {
                 objectType: ObjectType.Feature,
@@ -127,10 +134,10 @@ export default class Feature implements WarrantObject {
                 objectType: ObjectType.Tenant,
                 objectId: tenantId,
             }
-        });
+        }, options);
     }
 
-    public static async removeFeatureFromTenant(tenantId: string, featureId: string): Promise<void> {
+    public static async removeFeatureFromTenant(tenantId: string, featureId: string, options: UserRequestOptions = {}): Promise<void> {
         return WarrantModule.delete({
             object: {
                 objectType: ObjectType.Feature,
@@ -141,14 +148,15 @@ export default class Feature implements WarrantObject {
                 objectType: ObjectType.Tenant,
                 objectId: tenantId,
             }
-        });
+        }, options);
     }
 
-    public static async listFeaturesForUser(userId: string, listOptions: ListFeatureOptions = {}): Promise<Feature[]> {
+    public static async listFeaturesForUser(userId: string, listOptions: ListFeatureOptions = {}, options: UserRequestOptions = {}): Promise<Feature[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/users/${userId}/features`,
                 params: listOptions,
+                options,
             });
 
             return response.map((feature: Feature) => new Feature(feature.featureId));
@@ -157,7 +165,7 @@ export default class Feature implements WarrantObject {
         }
     }
 
-    public static async assignFeatureToUser(userId: string, featureId: string): Promise<Warrant> {
+    public static async assignFeatureToUser(userId: string, featureId: string, options: UserRequestOptions = {}): Promise<Warrant> {
         return WarrantModule.create({
             object: {
                 objectType: ObjectType.Feature,
@@ -168,10 +176,10 @@ export default class Feature implements WarrantObject {
                 objectType: ObjectType.User,
                 objectId: userId,
             }
-        });
+        }, options);
     }
 
-    public static async removeFeatureFromUser(userId: string, featureId: string): Promise<void> {
+    public static async removeFeatureFromUser(userId: string, featureId: string, options: UserRequestOptions = {}): Promise<void> {
         return WarrantModule.delete({
             object: {
                 objectType: ObjectType.Feature,
@@ -182,7 +190,7 @@ export default class Feature implements WarrantObject {
                 objectType: ObjectType.User,
                 objectId: userId,
             }
-        });
+        }, options);
     }
 
     // WarrantObject methods

--- a/src/modules/Feature.ts
+++ b/src/modules/Feature.ts
@@ -1,7 +1,7 @@
 import WarrantModule from "./WarrantModule";
 import WarrantClient from "../WarrantClient";
 import { CreateFeatureParams, ListFeatureOptions } from "../types/Feature";
-import { UserRequestOptions } from "../types/Params";
+import { WarrantRequestOptions } from "../types/WarrantRequestOptions";
 import Warrant, { WarrantObject } from "../types/Warrant";
 import { ObjectType } from "../types/ObjectType";
 
@@ -15,7 +15,7 @@ export default class Feature implements WarrantObject {
     //
     // Static methods
     //
-    public static async create(feature: CreateFeatureParams, options: UserRequestOptions = {}): Promise<Feature> {
+    public static async create(feature: CreateFeatureParams, options: WarrantRequestOptions = {}): Promise<Feature> {
         try {
             const response = await WarrantClient.httpClient.post({
                 url: "/v1/features",
@@ -29,7 +29,7 @@ export default class Feature implements WarrantObject {
         }
     }
 
-    public static async get(featureId: string, options: UserRequestOptions = {}): Promise<Feature> {
+    public static async get(featureId: string, options: WarrantRequestOptions = {}): Promise<Feature> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/features/${featureId}`,
@@ -42,7 +42,7 @@ export default class Feature implements WarrantObject {
         }
     }
 
-    public static async delete(featureId: string, options: UserRequestOptions = {}): Promise<void> {
+    public static async delete(featureId: string, options: WarrantRequestOptions = {}): Promise<void> {
         try {
             return await WarrantClient.httpClient.delete({
                 url: `/v1/features/${featureId}`,
@@ -53,7 +53,7 @@ export default class Feature implements WarrantObject {
         }
     }
 
-    public static async listFeatures(listOptions: ListFeatureOptions = {}, options: UserRequestOptions = {}): Promise<Feature[]> {
+    public static async listFeatures(listOptions: ListFeatureOptions = {}, options: WarrantRequestOptions = {}): Promise<Feature[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: "/v1/features",
@@ -67,7 +67,7 @@ export default class Feature implements WarrantObject {
         }
     }
 
-    public static async listFeaturesForPricingTier(pricingTierId: string, listOptions: ListFeatureOptions = {}, options: UserRequestOptions = {}): Promise<Feature[]> {
+    public static async listFeaturesForPricingTier(pricingTierId: string, listOptions: ListFeatureOptions = {}, options: WarrantRequestOptions = {}): Promise<Feature[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/pricing-tiers/${pricingTierId}/features`,
@@ -81,7 +81,7 @@ export default class Feature implements WarrantObject {
         }
     }
 
-    public static async assignFeatureToPricingTier(pricingTierId: string, featureId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+    public static async assignFeatureToPricingTier(pricingTierId: string, featureId: string, options: WarrantRequestOptions = {}): Promise<Warrant> {
         return WarrantModule.create({
             object: {
                 objectType: ObjectType.Feature,
@@ -95,7 +95,7 @@ export default class Feature implements WarrantObject {
         }, options);
     }
 
-    public static async removeFeatureFromPricingTier(pricingTierId: string, featureId: string, options: UserRequestOptions = {}): Promise<void> {
+    public static async removeFeatureFromPricingTier(pricingTierId: string, featureId: string, options: WarrantRequestOptions = {}): Promise<void> {
         return WarrantModule.delete({
             object: {
                 objectType: ObjectType.Feature,
@@ -109,7 +109,7 @@ export default class Feature implements WarrantObject {
         }, options);
     }
 
-    public static async listFeaturesForTenant(tenantId: string, listOptions: ListFeatureOptions = {}, options: UserRequestOptions = {}): Promise<Feature[]> {
+    public static async listFeaturesForTenant(tenantId: string, listOptions: ListFeatureOptions = {}, options: WarrantRequestOptions = {}): Promise<Feature[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/tenants/${tenantId}/features`,
@@ -123,7 +123,7 @@ export default class Feature implements WarrantObject {
         }
     }
 
-    public static async assignFeatureToTenant(tenantId: string, featureId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+    public static async assignFeatureToTenant(tenantId: string, featureId: string, options: WarrantRequestOptions = {}): Promise<Warrant> {
         return WarrantModule.create({
             object: {
                 objectType: ObjectType.Feature,
@@ -137,7 +137,7 @@ export default class Feature implements WarrantObject {
         }, options);
     }
 
-    public static async removeFeatureFromTenant(tenantId: string, featureId: string, options: UserRequestOptions = {}): Promise<void> {
+    public static async removeFeatureFromTenant(tenantId: string, featureId: string, options: WarrantRequestOptions = {}): Promise<void> {
         return WarrantModule.delete({
             object: {
                 objectType: ObjectType.Feature,
@@ -151,7 +151,7 @@ export default class Feature implements WarrantObject {
         }, options);
     }
 
-    public static async listFeaturesForUser(userId: string, listOptions: ListFeatureOptions = {}, options: UserRequestOptions = {}): Promise<Feature[]> {
+    public static async listFeaturesForUser(userId: string, listOptions: ListFeatureOptions = {}, options: WarrantRequestOptions = {}): Promise<Feature[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/users/${userId}/features`,
@@ -165,7 +165,7 @@ export default class Feature implements WarrantObject {
         }
     }
 
-    public static async assignFeatureToUser(userId: string, featureId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+    public static async assignFeatureToUser(userId: string, featureId: string, options: WarrantRequestOptions = {}): Promise<Warrant> {
         return WarrantModule.create({
             object: {
                 objectType: ObjectType.Feature,
@@ -179,7 +179,7 @@ export default class Feature implements WarrantObject {
         }, options);
     }
 
-    public static async removeFeatureFromUser(userId: string, featureId: string, options: UserRequestOptions = {}): Promise<void> {
+    public static async removeFeatureFromUser(userId: string, featureId: string, options: WarrantRequestOptions = {}): Promise<void> {
         return WarrantModule.delete({
             object: {
                 objectType: ObjectType.Feature,

--- a/src/modules/Permission.ts
+++ b/src/modules/Permission.ts
@@ -2,7 +2,7 @@ import WarrantModule from "./WarrantModule";
 import WarrantClient from "../WarrantClient";
 import { CreatePermissionParams, ListPermissionOptions, UpdatePermissionParams } from "../types/Permission";
 import { ObjectType } from "../types/ObjectType";
-import { UserRequestOptions } from "../types/Params";
+import { WarrantRequestOptions } from "../types/WarrantRequestOptions";
 import Warrant, { WarrantObject } from "../types/Warrant";
 
 export default class Permission implements WarrantObject {
@@ -19,7 +19,7 @@ export default class Permission implements WarrantObject {
     //
     // Static methods
     //
-    public static async create(permission: CreatePermissionParams, options: UserRequestOptions = {}): Promise<Permission> {
+    public static async create(permission: CreatePermissionParams, options: WarrantRequestOptions = {}): Promise<Permission> {
         try {
             const response = await WarrantClient.httpClient.post({
                 url: "/v1/permissions",
@@ -33,7 +33,7 @@ export default class Permission implements WarrantObject {
         }
     }
 
-    public static async get(permissionId: string, options: UserRequestOptions = {}): Promise<Permission> {
+    public static async get(permissionId: string, options: WarrantRequestOptions = {}): Promise<Permission> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/permissions/${permissionId}`,
@@ -46,7 +46,7 @@ export default class Permission implements WarrantObject {
         }
     }
 
-    public static async update(permissionId: string, permission: UpdatePermissionParams, options: UserRequestOptions = {}): Promise<Permission> {
+    public static async update(permissionId: string, permission: UpdatePermissionParams, options: WarrantRequestOptions = {}): Promise<Permission> {
         try {
             const response = await WarrantClient.httpClient.put({
                 url: `/v1/permissions/${permissionId}`,
@@ -60,7 +60,7 @@ export default class Permission implements WarrantObject {
         }
     }
 
-    public static async delete(permissionId: string, options: UserRequestOptions = {}): Promise<void> {
+    public static async delete(permissionId: string, options: WarrantRequestOptions = {}): Promise<void> {
         try {
             return await WarrantClient.httpClient.delete({
                 url: `/v1/permissions/${permissionId}`,
@@ -71,7 +71,7 @@ export default class Permission implements WarrantObject {
         }
     }
 
-    public static async listPermissions(listOptions: ListPermissionOptions = {}, options: UserRequestOptions = {}): Promise<Permission[]> {
+    public static async listPermissions(listOptions: ListPermissionOptions = {}, options: WarrantRequestOptions = {}): Promise<Permission[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: "/v1/permissions",
@@ -85,7 +85,7 @@ export default class Permission implements WarrantObject {
         }
     }
 
-    public static async listPermissionsForUser(userId: string, listOptions: ListPermissionOptions = {}, options: UserRequestOptions = {}): Promise<Permission[]> {
+    public static async listPermissionsForUser(userId: string, listOptions: ListPermissionOptions = {}, options: WarrantRequestOptions = {}): Promise<Permission[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/users/${userId}/permissions`,
@@ -99,7 +99,7 @@ export default class Permission implements WarrantObject {
         }
     }
 
-    public static async assignPermissionToUser(userId: string, permissionId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+    public static async assignPermissionToUser(userId: string, permissionId: string, options: WarrantRequestOptions = {}): Promise<Warrant> {
         return WarrantModule.create({
             object: {
                 objectType: ObjectType.Permission,
@@ -113,7 +113,7 @@ export default class Permission implements WarrantObject {
         }, options);
     }
 
-    public static async removePermissionFromUser(userId: string, permissionId: string, options: UserRequestOptions = {}): Promise<void> {
+    public static async removePermissionFromUser(userId: string, permissionId: string, options: WarrantRequestOptions = {}): Promise<void> {
         return WarrantModule.delete({
             object: {
                 objectType: ObjectType.Permission,
@@ -127,7 +127,7 @@ export default class Permission implements WarrantObject {
         }, options);
     }
 
-    public static async listPermissionsForRole(roleId: string, listOptions: ListPermissionOptions = {}, options: UserRequestOptions = {}): Promise<Permission[]> {
+    public static async listPermissionsForRole(roleId: string, listOptions: ListPermissionOptions = {}, options: WarrantRequestOptions = {}): Promise<Permission[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/roles/${roleId}/permissions`,
@@ -141,7 +141,7 @@ export default class Permission implements WarrantObject {
         }
     }
 
-    public static async assignPermissionToRole(roleId: string, permissionId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+    public static async assignPermissionToRole(roleId: string, permissionId: string, options: WarrantRequestOptions = {}): Promise<Warrant> {
         return WarrantModule.create({
             object: {
                 objectType: ObjectType.Permission,
@@ -155,7 +155,7 @@ export default class Permission implements WarrantObject {
         }, options);
     }
 
-    public static async removePermissionFromRole(roleId: string, permissionId: string, options: UserRequestOptions = {}): Promise<void> {
+    public static async removePermissionFromRole(roleId: string, permissionId: string, options: WarrantRequestOptions = {}): Promise<void> {
         return WarrantModule.delete({
             object: {
                 objectType: ObjectType.Permission,

--- a/src/modules/Permission.ts
+++ b/src/modules/Permission.ts
@@ -2,6 +2,7 @@ import WarrantModule from "./WarrantModule";
 import WarrantClient from "../WarrantClient";
 import { CreatePermissionParams, ListPermissionOptions, UpdatePermissionParams } from "../types/Permission";
 import { ObjectType } from "../types/ObjectType";
+import { UserRequestOptions } from "../types/Params";
 import Warrant, { WarrantObject } from "../types/Warrant";
 
 export default class Permission implements WarrantObject {
@@ -18,11 +19,12 @@ export default class Permission implements WarrantObject {
     //
     // Static methods
     //
-    public static async create(permission: CreatePermissionParams): Promise<Permission> {
+    public static async create(permission: CreatePermissionParams, options: UserRequestOptions = {}): Promise<Permission> {
         try {
             const response = await WarrantClient.httpClient.post({
                 url: "/v1/permissions",
                 data: permission,
+                options,
             });
 
             return new Permission(response.permissionId, response.name, response.description);
@@ -31,10 +33,11 @@ export default class Permission implements WarrantObject {
         }
     }
 
-    public static async get(permissionId: string): Promise<Permission> {
+    public static async get(permissionId: string, options: UserRequestOptions = {}): Promise<Permission> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/permissions/${permissionId}`,
+                options,
             });
 
             return new Permission(response.permissionId, response.name, response.description);
@@ -43,11 +46,12 @@ export default class Permission implements WarrantObject {
         }
     }
 
-    public static async update(permissionId: string, permission: UpdatePermissionParams): Promise<Permission> {
+    public static async update(permissionId: string, permission: UpdatePermissionParams, options: UserRequestOptions = {}): Promise<Permission> {
         try {
             const response = await WarrantClient.httpClient.put({
                 url: `/v1/permissions/${permissionId}`,
                 data: permission,
+                options,
             });
 
             return new Permission(response.permissionId, response.name, response.description);
@@ -56,21 +60,23 @@ export default class Permission implements WarrantObject {
         }
     }
 
-    public static async delete(permissionId: string): Promise<void> {
+    public static async delete(permissionId: string, options: UserRequestOptions = {}): Promise<void> {
         try {
             return await WarrantClient.httpClient.delete({
                 url: `/v1/permissions/${permissionId}`,
+                options,
             });
         } catch (e) {
             throw e;
         }
     }
 
-    public static async listPermissions(listOptions: ListPermissionOptions = {}): Promise<Permission[]> {
+    public static async listPermissions(listOptions: ListPermissionOptions = {}, options: UserRequestOptions = {}): Promise<Permission[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: "/v1/permissions",
                 params: listOptions,
+                options,
             });
 
             return response.map((permission: Permission) => new Permission(permission.permissionId, permission.name, permission.description));
@@ -79,11 +85,12 @@ export default class Permission implements WarrantObject {
         }
     }
 
-    public static async listPermissionsForUser(userId: string, listOptions: ListPermissionOptions = {}): Promise<Permission[]> {
+    public static async listPermissionsForUser(userId: string, listOptions: ListPermissionOptions = {}, options: UserRequestOptions = {}): Promise<Permission[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/users/${userId}/permissions`,
                 params: listOptions,
+                options,
             });
 
             return response.map((permission: Permission) => new Permission(permission.permissionId, permission.name, permission.description));
@@ -92,7 +99,7 @@ export default class Permission implements WarrantObject {
         }
     }
 
-    public static async assignPermissionToUser(userId: string, permissionId: string): Promise<Warrant> {
+    public static async assignPermissionToUser(userId: string, permissionId: string, options: UserRequestOptions = {}): Promise<Warrant> {
         return WarrantModule.create({
             object: {
                 objectType: ObjectType.Permission,
@@ -103,10 +110,10 @@ export default class Permission implements WarrantObject {
                 objectType: ObjectType.User,
                 objectId: userId,
             }
-        });
+        }, options);
     }
 
-    public static async removePermissionFromUser(userId: string, permissionId: string): Promise<void> {
+    public static async removePermissionFromUser(userId: string, permissionId: string, options: UserRequestOptions = {}): Promise<void> {
         return WarrantModule.delete({
             object: {
                 objectType: ObjectType.Permission,
@@ -117,14 +124,15 @@ export default class Permission implements WarrantObject {
                 objectType: ObjectType.User,
                 objectId: userId,
             }
-        });
+        }, options);
     }
 
-    public static async listPermissionsForRole(roleId: string, listOptions: ListPermissionOptions = {}): Promise<Permission[]> {
+    public static async listPermissionsForRole(roleId: string, listOptions: ListPermissionOptions = {}, options: UserRequestOptions = {}): Promise<Permission[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/roles/${roleId}/permissions`,
                 params: listOptions,
+                options,
             });
 
             return response.map((permission: Permission) => new Permission(permission.permissionId, permission.name, permission.description));
@@ -133,7 +141,7 @@ export default class Permission implements WarrantObject {
         }
     }
 
-    public static async assignPermissionToRole(roleId: string, permissionId: string): Promise<Warrant> {
+    public static async assignPermissionToRole(roleId: string, permissionId: string, options: UserRequestOptions = {}): Promise<Warrant> {
         return WarrantModule.create({
             object: {
                 objectType: ObjectType.Permission,
@@ -144,10 +152,10 @@ export default class Permission implements WarrantObject {
                 objectType: ObjectType.Role,
                 objectId: roleId,
             }
-        });
+        }, options);
     }
 
-    public static async removePermissionFromRole(roleId: string, permissionId: string): Promise<void> {
+    public static async removePermissionFromRole(roleId: string, permissionId: string, options: UserRequestOptions = {}): Promise<void> {
         return WarrantModule.delete({
             object: {
                 objectType: ObjectType.Permission,
@@ -158,7 +166,7 @@ export default class Permission implements WarrantObject {
                 objectType: ObjectType.Role,
                 objectId: roleId,
             }
-        });
+        }, options);
     }
 
     // WarrantObject methods

--- a/src/modules/PricingTier.ts
+++ b/src/modules/PricingTier.ts
@@ -4,6 +4,7 @@ import WarrantModule from "./WarrantModule";
 import WarrantClient from "../WarrantClient";
 import { ListFeatureOptions } from "../types/Feature";
 import { ObjectType } from "../types/ObjectType";
+import { UserRequestOptions } from "../types/Params";
 import { CreatePricingTierParams, ListPricingTierOptions } from "../types/PricingTier";
 import Warrant, { PolicyContext, WarrantObject } from "../types/Warrant";
 
@@ -17,11 +18,12 @@ export default class PricingTier implements WarrantObject {
     //
     // Static methods
     //
-    public static async create(pricingTier: CreatePricingTierParams): Promise<PricingTier> {
+    public static async create(pricingTier: CreatePricingTierParams, options: UserRequestOptions = {}): Promise<PricingTier> {
         try {
             const response = await WarrantClient.httpClient.post({
                 url: "/v1/pricing-tiers",
                 data: pricingTier,
+                options,
             });
 
             return new PricingTier(response.pricingTierId);
@@ -30,10 +32,11 @@ export default class PricingTier implements WarrantObject {
         }
     }
 
-    public static async get(pricingTierId: string): Promise<PricingTier> {
+    public static async get(pricingTierId: string, options: UserRequestOptions = {}): Promise<PricingTier> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/pricing-tiers/${pricingTierId}`,
+                options,
             });
 
             return new PricingTier(response.pricingTierId);
@@ -42,21 +45,23 @@ export default class PricingTier implements WarrantObject {
         }
     }
 
-    public static async delete(pricingTierId: string): Promise<void> {
+    public static async delete(pricingTierId: string, options: UserRequestOptions = {}): Promise<void> {
         try {
             return await WarrantClient.httpClient.delete({
                 url: `/v1/pricing-tiers/${pricingTierId}`,
+                options,
             });
         } catch (e) {
             throw e;
         }
     }
 
-    public static async listPricingTiers(listOptions: ListPricingTierOptions = {}): Promise<PricingTier[]> {
+    public static async listPricingTiers(listOptions: ListPricingTierOptions = {}, options: UserRequestOptions = {}): Promise<PricingTier[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: "/v1/pricing-tiers",
                 params: listOptions,
+                options,
             });
 
             return response.map((pricingTier: PricingTier) => new PricingTier(pricingTier.pricingTierId));
@@ -65,11 +70,12 @@ export default class PricingTier implements WarrantObject {
         }
     }
 
-    public static async listPricingTiersForTenant(tenantId: string, listOptions: ListPricingTierOptions = {}): Promise<PricingTier[]> {
+    public static async listPricingTiersForTenant(tenantId: string, listOptions: ListPricingTierOptions = {}, options: UserRequestOptions = {}): Promise<PricingTier[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/tenants/${tenantId}/pricing-tiers`,
                 params: listOptions,
+                options,
             });
 
             return response.map((pricingTier: PricingTier) => new PricingTier(pricingTier.pricingTierId));
@@ -78,7 +84,7 @@ export default class PricingTier implements WarrantObject {
         }
     }
 
-    public static async assignPricingTierToTenant(tenantId: string, pricingTierId: string): Promise<Warrant> {
+    public static async assignPricingTierToTenant(tenantId: string, pricingTierId: string, options: UserRequestOptions = {}): Promise<Warrant> {
         return WarrantModule.create({
             object: {
                 objectType: ObjectType.PricingTier,
@@ -89,10 +95,10 @@ export default class PricingTier implements WarrantObject {
                 objectType: ObjectType.Tenant,
                 objectId: tenantId,
             }
-        });
+        }, options);
     }
 
-    public static async removePricingTierFromTenant(tenantId: string, pricingTierId: string): Promise<void> {
+    public static async removePricingTierFromTenant(tenantId: string, pricingTierId: string, options: UserRequestOptions = {}): Promise<void> {
         return WarrantModule.delete({
             object: {
                 objectType: ObjectType.PricingTier,
@@ -103,14 +109,15 @@ export default class PricingTier implements WarrantObject {
                 objectType: ObjectType.Tenant,
                 objectId: tenantId,
             }
-        });
+        }, options);
     }
 
-    public static async listPricingTiersForUser(userId: string, listOptions: ListPricingTierOptions = {}): Promise<PricingTier[]> {
+    public static async listPricingTiersForUser(userId: string, listOptions: ListPricingTierOptions = {}, options: UserRequestOptions = {}): Promise<PricingTier[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/users/${userId}/pricing-tiers`,
                 params: listOptions,
+                options,
             });
 
             return response.map((pricingTier: PricingTier) => new PricingTier(pricingTier.pricingTierId));
@@ -119,7 +126,7 @@ export default class PricingTier implements WarrantObject {
         }
     }
 
-    public static async assignPricingTierToUser(userId: string, pricingTierId: string): Promise<Warrant> {
+    public static async assignPricingTierToUser(userId: string, pricingTierId: string, options: UserRequestOptions = {}): Promise<Warrant> {
         return WarrantModule.create({
             object: {
                 objectType: ObjectType.PricingTier,
@@ -130,10 +137,10 @@ export default class PricingTier implements WarrantObject {
                 objectType: ObjectType.User,
                 objectId: userId,
             }
-        });
+        }, options);
     }
 
-    public static async removePricingTierFromUser(userId: string, pricingTierId: string): Promise<void> {
+    public static async removePricingTierFromUser(userId: string, pricingTierId: string, options: UserRequestOptions = {}): Promise<void> {
         return WarrantModule.delete({
             object: {
                 objectType: ObjectType.PricingTier,
@@ -144,24 +151,24 @@ export default class PricingTier implements WarrantObject {
                 objectType: ObjectType.User,
                 objectId: userId,
             }
-        });
+        }, options);
     }
 
     // Instance methods
-    public async listFeatures(listOptions: ListFeatureOptions = {}): Promise<Feature[]> {
-        return Feature.listFeaturesForPricingTier(this.pricingTierId, listOptions);
+    public async listFeatures(listOptions: ListFeatureOptions = {}, options: UserRequestOptions = {}): Promise<Feature[]> {
+        return Feature.listFeaturesForPricingTier(this.pricingTierId, listOptions, options);
     }
 
-    public async assignFeature(featureId: string): Promise<Warrant> {
-        return Feature.assignFeatureToPricingTier(this.pricingTierId, featureId);
+    public async assignFeature(featureId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+        return Feature.assignFeatureToPricingTier(this.pricingTierId, featureId, options);
     }
 
-    public async removeFeature(featureId: string): Promise<void> {
-        return Feature.removeFeatureFromPricingTier(this.pricingTierId, featureId);
+    public async removeFeature(featureId: string, options: UserRequestOptions = {}): Promise<void> {
+        return Feature.removeFeatureFromPricingTier(this.pricingTierId, featureId, options);
     }
 
-    public async hasFeature(featureId: string, context: PolicyContext = {}): Promise<boolean> {
-        return Authorization.hasFeature({ featureId: featureId, subject: { objectType: ObjectType.PricingTier, objectId: this.pricingTierId }, context: context });
+    public async hasFeature(featureId: string, context: PolicyContext = {}, options: UserRequestOptions = {}): Promise<boolean> {
+        return Authorization.hasFeature({ featureId: featureId, subject: { objectType: ObjectType.PricingTier, objectId: this.pricingTierId }, context: context }, options);
     }
 
     // WarrantObject methods

--- a/src/modules/PricingTier.ts
+++ b/src/modules/PricingTier.ts
@@ -4,7 +4,7 @@ import WarrantModule from "./WarrantModule";
 import WarrantClient from "../WarrantClient";
 import { ListFeatureOptions } from "../types/Feature";
 import { ObjectType } from "../types/ObjectType";
-import { UserRequestOptions } from "../types/Params";
+import { WarrantRequestOptions } from "../types/WarrantRequestOptions";
 import { CreatePricingTierParams, ListPricingTierOptions } from "../types/PricingTier";
 import Warrant, { PolicyContext, WarrantObject } from "../types/Warrant";
 
@@ -18,7 +18,7 @@ export default class PricingTier implements WarrantObject {
     //
     // Static methods
     //
-    public static async create(pricingTier: CreatePricingTierParams, options: UserRequestOptions = {}): Promise<PricingTier> {
+    public static async create(pricingTier: CreatePricingTierParams, options: WarrantRequestOptions = {}): Promise<PricingTier> {
         try {
             const response = await WarrantClient.httpClient.post({
                 url: "/v1/pricing-tiers",
@@ -32,7 +32,7 @@ export default class PricingTier implements WarrantObject {
         }
     }
 
-    public static async get(pricingTierId: string, options: UserRequestOptions = {}): Promise<PricingTier> {
+    public static async get(pricingTierId: string, options: WarrantRequestOptions = {}): Promise<PricingTier> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/pricing-tiers/${pricingTierId}`,
@@ -45,7 +45,7 @@ export default class PricingTier implements WarrantObject {
         }
     }
 
-    public static async delete(pricingTierId: string, options: UserRequestOptions = {}): Promise<void> {
+    public static async delete(pricingTierId: string, options: WarrantRequestOptions = {}): Promise<void> {
         try {
             return await WarrantClient.httpClient.delete({
                 url: `/v1/pricing-tiers/${pricingTierId}`,
@@ -56,7 +56,7 @@ export default class PricingTier implements WarrantObject {
         }
     }
 
-    public static async listPricingTiers(listOptions: ListPricingTierOptions = {}, options: UserRequestOptions = {}): Promise<PricingTier[]> {
+    public static async listPricingTiers(listOptions: ListPricingTierOptions = {}, options: WarrantRequestOptions = {}): Promise<PricingTier[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: "/v1/pricing-tiers",
@@ -70,7 +70,7 @@ export default class PricingTier implements WarrantObject {
         }
     }
 
-    public static async listPricingTiersForTenant(tenantId: string, listOptions: ListPricingTierOptions = {}, options: UserRequestOptions = {}): Promise<PricingTier[]> {
+    public static async listPricingTiersForTenant(tenantId: string, listOptions: ListPricingTierOptions = {}, options: WarrantRequestOptions = {}): Promise<PricingTier[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/tenants/${tenantId}/pricing-tiers`,
@@ -84,7 +84,7 @@ export default class PricingTier implements WarrantObject {
         }
     }
 
-    public static async assignPricingTierToTenant(tenantId: string, pricingTierId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+    public static async assignPricingTierToTenant(tenantId: string, pricingTierId: string, options: WarrantRequestOptions = {}): Promise<Warrant> {
         return WarrantModule.create({
             object: {
                 objectType: ObjectType.PricingTier,
@@ -98,7 +98,7 @@ export default class PricingTier implements WarrantObject {
         }, options);
     }
 
-    public static async removePricingTierFromTenant(tenantId: string, pricingTierId: string, options: UserRequestOptions = {}): Promise<void> {
+    public static async removePricingTierFromTenant(tenantId: string, pricingTierId: string, options: WarrantRequestOptions = {}): Promise<void> {
         return WarrantModule.delete({
             object: {
                 objectType: ObjectType.PricingTier,
@@ -112,7 +112,7 @@ export default class PricingTier implements WarrantObject {
         }, options);
     }
 
-    public static async listPricingTiersForUser(userId: string, listOptions: ListPricingTierOptions = {}, options: UserRequestOptions = {}): Promise<PricingTier[]> {
+    public static async listPricingTiersForUser(userId: string, listOptions: ListPricingTierOptions = {}, options: WarrantRequestOptions = {}): Promise<PricingTier[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/users/${userId}/pricing-tiers`,
@@ -126,7 +126,7 @@ export default class PricingTier implements WarrantObject {
         }
     }
 
-    public static async assignPricingTierToUser(userId: string, pricingTierId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+    public static async assignPricingTierToUser(userId: string, pricingTierId: string, options: WarrantRequestOptions = {}): Promise<Warrant> {
         return WarrantModule.create({
             object: {
                 objectType: ObjectType.PricingTier,
@@ -140,7 +140,7 @@ export default class PricingTier implements WarrantObject {
         }, options);
     }
 
-    public static async removePricingTierFromUser(userId: string, pricingTierId: string, options: UserRequestOptions = {}): Promise<void> {
+    public static async removePricingTierFromUser(userId: string, pricingTierId: string, options: WarrantRequestOptions = {}): Promise<void> {
         return WarrantModule.delete({
             object: {
                 objectType: ObjectType.PricingTier,
@@ -155,19 +155,19 @@ export default class PricingTier implements WarrantObject {
     }
 
     // Instance methods
-    public async listFeatures(listOptions: ListFeatureOptions = {}, options: UserRequestOptions = {}): Promise<Feature[]> {
+    public async listFeatures(listOptions: ListFeatureOptions = {}, options: WarrantRequestOptions = {}): Promise<Feature[]> {
         return Feature.listFeaturesForPricingTier(this.pricingTierId, listOptions, options);
     }
 
-    public async assignFeature(featureId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+    public async assignFeature(featureId: string, options: WarrantRequestOptions = {}): Promise<Warrant> {
         return Feature.assignFeatureToPricingTier(this.pricingTierId, featureId, options);
     }
 
-    public async removeFeature(featureId: string, options: UserRequestOptions = {}): Promise<void> {
+    public async removeFeature(featureId: string, options: WarrantRequestOptions = {}): Promise<void> {
         return Feature.removeFeatureFromPricingTier(this.pricingTierId, featureId, options);
     }
 
-    public async hasFeature(featureId: string, context: PolicyContext = {}, options: UserRequestOptions = {}): Promise<boolean> {
+    public async hasFeature(featureId: string, context: PolicyContext = {}, options: WarrantRequestOptions = {}): Promise<boolean> {
         return Authorization.hasFeature({ featureId: featureId, subject: { objectType: ObjectType.PricingTier, objectId: this.pricingTierId }, context: context }, options);
     }
 

--- a/src/modules/Role.ts
+++ b/src/modules/Role.ts
@@ -3,6 +3,7 @@ import Permission from "./Permission";
 import WarrantModule from "./WarrantModule";
 import WarrantClient from "../WarrantClient";
 import { ObjectType } from "../types/ObjectType";
+import { UserRequestOptions } from "../types/Params";
 import { ListPermissionOptions } from "../types/Permission";
 import { CreateRoleParams, ListRoleOptions, UpdateRoleParams } from "../types/Role";
 import Warrant, { PolicyContext, WarrantObject } from "../types/Warrant";
@@ -21,11 +22,12 @@ export default class Role implements WarrantObject {
     //
     // Static methods
     //
-    public static async create(role: CreateRoleParams): Promise<Role> {
+    public static async create(role: CreateRoleParams, options: UserRequestOptions = {}): Promise<Role> {
         try {
             const response = await WarrantClient.httpClient.post({
                 url: "/v1/roles",
                 data: role,
+                options,
             });
 
             return new Role(response.roleId, response.name, response.description);
@@ -34,10 +36,11 @@ export default class Role implements WarrantObject {
         }
     }
 
-    public static async get(roleId: string): Promise<Role> {
+    public static async get(roleId: string, options: UserRequestOptions = {}): Promise<Role> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/roles/${roleId}`,
+                options,
             });
 
             return new Role(response.roleId, response.name, response.description);
@@ -46,11 +49,12 @@ export default class Role implements WarrantObject {
         }
     }
 
-    public static async update(roleId: string, role: UpdateRoleParams): Promise<Role> {
+    public static async update(roleId: string, role: UpdateRoleParams, options: UserRequestOptions = {}): Promise<Role> {
         try {
             const response = await WarrantClient.httpClient.put({
                 url: `/v1/roles/${roleId}`,
                 data: role,
+                options,
             });
 
             return new Role(response.roleId, response.name, response.description);
@@ -59,21 +63,23 @@ export default class Role implements WarrantObject {
         }
     }
 
-    public static async delete(roleId: string): Promise<void> {
+    public static async delete(roleId: string, options: UserRequestOptions = {}): Promise<void> {
         try {
             return await WarrantClient.httpClient.delete({
                 url: `/v1/roles/${roleId}`,
+                options,
             });
         } catch (e) {
             throw e;
         }
     }
 
-    public static async listRoles(listOptions: ListRoleOptions = {}): Promise<Role[]> {
+    public static async listRoles(listOptions: ListRoleOptions = {}, options: UserRequestOptions = {}): Promise<Role[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: "/v1/roles",
                 params: listOptions,
+                options,
             });
 
             return response.map((role: Role) => new Role(role.roleId, role.name, role.description));
@@ -82,11 +88,12 @@ export default class Role implements WarrantObject {
         }
     }
 
-    public static async listRolesForUser(userId: string, listOptions: ListRoleOptions = {}): Promise<Role[]> {
+    public static async listRolesForUser(userId: string, listOptions: ListRoleOptions = {}, options: UserRequestOptions = {}): Promise<Role[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/users/${userId}/roles`,
                 params: listOptions,
+                options,
             });
 
             return response.map((role: Role) => new Role(role.roleId, role.name, role.description));
@@ -95,7 +102,7 @@ export default class Role implements WarrantObject {
         }
     }
 
-    public static async assignRoleToUser(userId: string, roleId: string): Promise<Warrant> {
+    public static async assignRoleToUser(userId: string, roleId: string, options: UserRequestOptions = {}): Promise<Warrant> {
         return WarrantModule.create({
             object: {
                 objectType: ObjectType.Role,
@@ -106,10 +113,10 @@ export default class Role implements WarrantObject {
                 objectType: ObjectType.User,
                 objectId: userId,
             }
-        });
+        }, options);
     }
 
-    public static async removeRoleFromUser(userId: string, roleId: string): Promise<void> {
+    public static async removeRoleFromUser(userId: string, roleId: string, options: UserRequestOptions = {}): Promise<void> {
         return WarrantModule.delete({
             object: {
                 objectType: ObjectType.Role,
@@ -120,24 +127,24 @@ export default class Role implements WarrantObject {
                 objectType: ObjectType.User,
                 objectId: userId,
             }
-        });
+        }, options);
     }
 
     // Instance methods
-    public async listPermissions(listOptions: ListPermissionOptions = {}): Promise<Permission[]> {
-        return Permission.listPermissionsForRole(this.roleId, listOptions);
+    public async listPermissions(listOptions: ListPermissionOptions = {}, options: UserRequestOptions = {}): Promise<Permission[]> {
+        return Permission.listPermissionsForRole(this.roleId, listOptions, options);
     }
 
-    public async assignPermission(permissionId: string): Promise<Warrant> {
-        return Permission.assignPermissionToRole(this.roleId, permissionId);
+    public async assignPermission(permissionId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+        return Permission.assignPermissionToRole(this.roleId, permissionId, options);
     }
 
-    public async removePermission(permissionId: string): Promise<void> {
-        return Permission.removePermissionFromRole(this.roleId, permissionId);
+    public async removePermission(permissionId: string, options: UserRequestOptions = {}): Promise<void> {
+        return Permission.removePermissionFromRole(this.roleId, permissionId, options);
     }
 
-    public async hasPermission(permissionId: string, context: PolicyContext = {}): Promise<boolean> {
-        return Authorization.hasPermission({ permissionId: permissionId, subject: { objectType: ObjectType.Role, objectId: this.roleId }, context: context });
+    public async hasPermission(permissionId: string, context: PolicyContext = {}, options: UserRequestOptions = {}): Promise<boolean> {
+        return Authorization.hasPermission({ permissionId: permissionId, subject: { objectType: ObjectType.Role, objectId: this.roleId }, context: context }, options);
     }
 
     // WarrantObject methods

--- a/src/modules/Role.ts
+++ b/src/modules/Role.ts
@@ -3,7 +3,7 @@ import Permission from "./Permission";
 import WarrantModule from "./WarrantModule";
 import WarrantClient from "../WarrantClient";
 import { ObjectType } from "../types/ObjectType";
-import { UserRequestOptions } from "../types/Params";
+import { WarrantRequestOptions } from "../types/WarrantRequestOptions";
 import { ListPermissionOptions } from "../types/Permission";
 import { CreateRoleParams, ListRoleOptions, UpdateRoleParams } from "../types/Role";
 import Warrant, { PolicyContext, WarrantObject } from "../types/Warrant";
@@ -22,7 +22,7 @@ export default class Role implements WarrantObject {
     //
     // Static methods
     //
-    public static async create(role: CreateRoleParams, options: UserRequestOptions = {}): Promise<Role> {
+    public static async create(role: CreateRoleParams, options: WarrantRequestOptions = {}): Promise<Role> {
         try {
             const response = await WarrantClient.httpClient.post({
                 url: "/v1/roles",
@@ -36,7 +36,7 @@ export default class Role implements WarrantObject {
         }
     }
 
-    public static async get(roleId: string, options: UserRequestOptions = {}): Promise<Role> {
+    public static async get(roleId: string, options: WarrantRequestOptions = {}): Promise<Role> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/roles/${roleId}`,
@@ -49,7 +49,7 @@ export default class Role implements WarrantObject {
         }
     }
 
-    public static async update(roleId: string, role: UpdateRoleParams, options: UserRequestOptions = {}): Promise<Role> {
+    public static async update(roleId: string, role: UpdateRoleParams, options: WarrantRequestOptions = {}): Promise<Role> {
         try {
             const response = await WarrantClient.httpClient.put({
                 url: `/v1/roles/${roleId}`,
@@ -63,7 +63,7 @@ export default class Role implements WarrantObject {
         }
     }
 
-    public static async delete(roleId: string, options: UserRequestOptions = {}): Promise<void> {
+    public static async delete(roleId: string, options: WarrantRequestOptions = {}): Promise<void> {
         try {
             return await WarrantClient.httpClient.delete({
                 url: `/v1/roles/${roleId}`,
@@ -74,7 +74,7 @@ export default class Role implements WarrantObject {
         }
     }
 
-    public static async listRoles(listOptions: ListRoleOptions = {}, options: UserRequestOptions = {}): Promise<Role[]> {
+    public static async listRoles(listOptions: ListRoleOptions = {}, options: WarrantRequestOptions = {}): Promise<Role[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: "/v1/roles",
@@ -88,7 +88,7 @@ export default class Role implements WarrantObject {
         }
     }
 
-    public static async listRolesForUser(userId: string, listOptions: ListRoleOptions = {}, options: UserRequestOptions = {}): Promise<Role[]> {
+    public static async listRolesForUser(userId: string, listOptions: ListRoleOptions = {}, options: WarrantRequestOptions = {}): Promise<Role[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/users/${userId}/roles`,
@@ -102,7 +102,7 @@ export default class Role implements WarrantObject {
         }
     }
 
-    public static async assignRoleToUser(userId: string, roleId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+    public static async assignRoleToUser(userId: string, roleId: string, options: WarrantRequestOptions = {}): Promise<Warrant> {
         return WarrantModule.create({
             object: {
                 objectType: ObjectType.Role,
@@ -116,7 +116,7 @@ export default class Role implements WarrantObject {
         }, options);
     }
 
-    public static async removeRoleFromUser(userId: string, roleId: string, options: UserRequestOptions = {}): Promise<void> {
+    public static async removeRoleFromUser(userId: string, roleId: string, options: WarrantRequestOptions = {}): Promise<void> {
         return WarrantModule.delete({
             object: {
                 objectType: ObjectType.Role,
@@ -131,19 +131,19 @@ export default class Role implements WarrantObject {
     }
 
     // Instance methods
-    public async listPermissions(listOptions: ListPermissionOptions = {}, options: UserRequestOptions = {}): Promise<Permission[]> {
+    public async listPermissions(listOptions: ListPermissionOptions = {}, options: WarrantRequestOptions = {}): Promise<Permission[]> {
         return Permission.listPermissionsForRole(this.roleId, listOptions, options);
     }
 
-    public async assignPermission(permissionId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+    public async assignPermission(permissionId: string, options: WarrantRequestOptions = {}): Promise<Warrant> {
         return Permission.assignPermissionToRole(this.roleId, permissionId, options);
     }
 
-    public async removePermission(permissionId: string, options: UserRequestOptions = {}): Promise<void> {
+    public async removePermission(permissionId: string, options: WarrantRequestOptions = {}): Promise<void> {
         return Permission.removePermissionFromRole(this.roleId, permissionId, options);
     }
 
-    public async hasPermission(permissionId: string, context: PolicyContext = {}, options: UserRequestOptions = {}): Promise<boolean> {
+    public async hasPermission(permissionId: string, context: PolicyContext = {}, options: WarrantRequestOptions = {}): Promise<boolean> {
         return Authorization.hasPermission({ permissionId: permissionId, subject: { objectType: ObjectType.Role, objectId: this.roleId }, context: context }, options);
     }
 

--- a/src/modules/Session.ts
+++ b/src/modules/Session.ts
@@ -1,5 +1,6 @@
 import WarrantClient from "../WarrantClient";
 import { SELF_SERVICE_DASH_URL_BASE } from "../constants";
+import { UserRequestOptions } from "../types/Params";
 import { SelfServiceSessionParams, SessionParams } from "../types/Session";
 
 export default class Session {
@@ -10,7 +11,7 @@ export default class Session {
      * @param session A session object containing the userId, redirectUrl, and optional tenantId for which the authorization session should be created.
      * @returns A session token that can be passed to any of the Warrant client-side SDKs to allow the SDK to make client-side authorization checks for the specified user.
      */
-    public static async createAuthorizationSession(session: SessionParams): Promise<string> {
+    public static async createAuthorizationSession(session: SessionParams, options: UserRequestOptions = {}): Promise<string> {
         try {
             const sess = await WarrantClient.httpClient.post({
                 url: "/v1/sessions",
@@ -18,6 +19,7 @@ export default class Session {
                     ...session,
                     type: "sess",
                 },
+                options,
             });
 
             return sess.token;
@@ -33,7 +35,7 @@ export default class Session {
      * @param session A session object containing the userId, redirectUrl, and optional tenantId for which the self service session should be created.
      * @returns A url pointing to the self-service dashboard that will allow the specified user to make changes to the roles and permissions of users in their tenant.
      */
-    public static async createSelfServiceSession(session: SelfServiceSessionParams, redirectUrl: string): Promise<string> {
+    public static async createSelfServiceSession(session: SelfServiceSessionParams, redirectUrl: string, options: UserRequestOptions = {}): Promise<string> {
         try {
             const sess = await WarrantClient.httpClient.post({
                 url: "/v1/sessions",
@@ -41,6 +43,7 @@ export default class Session {
                     ...session,
                     type: "ssdash",
                 },
+                options,
             });
 
             return `${SELF_SERVICE_DASH_URL_BASE}/${sess.token}?redirectUrl=${redirectUrl}`;

--- a/src/modules/Session.ts
+++ b/src/modules/Session.ts
@@ -1,6 +1,6 @@
 import WarrantClient from "../WarrantClient";
 import { SELF_SERVICE_DASH_URL_BASE } from "../constants";
-import { UserRequestOptions } from "../types/Params";
+import { WarrantRequestOptions } from "../types/WarrantRequestOptions";
 import { SelfServiceSessionParams, SessionParams } from "../types/Session";
 
 export default class Session {
@@ -11,7 +11,7 @@ export default class Session {
      * @param session A session object containing the userId, redirectUrl, and optional tenantId for which the authorization session should be created.
      * @returns A session token that can be passed to any of the Warrant client-side SDKs to allow the SDK to make client-side authorization checks for the specified user.
      */
-    public static async createAuthorizationSession(session: SessionParams, options: UserRequestOptions = {}): Promise<string> {
+    public static async createAuthorizationSession(session: SessionParams, options: WarrantRequestOptions = {}): Promise<string> {
         try {
             const sess = await WarrantClient.httpClient.post({
                 url: "/v1/sessions",
@@ -35,7 +35,7 @@ export default class Session {
      * @param session A session object containing the userId, redirectUrl, and optional tenantId for which the self service session should be created.
      * @returns A url pointing to the self-service dashboard that will allow the specified user to make changes to the roles and permissions of users in their tenant.
      */
-    public static async createSelfServiceSession(session: SelfServiceSessionParams, redirectUrl: string, options: UserRequestOptions = {}): Promise<string> {
+    public static async createSelfServiceSession(session: SelfServiceSessionParams, redirectUrl: string, options: WarrantRequestOptions = {}): Promise<string> {
         try {
             const sess = await WarrantClient.httpClient.post({
                 url: "/v1/sessions",

--- a/src/modules/Tenant.ts
+++ b/src/modules/Tenant.ts
@@ -6,7 +6,7 @@ import WarrantClient from "../WarrantClient";
 import Warrant from "./WarrantModule";
 import { ListFeatureOptions } from "../types/Feature";
 import { ObjectType } from "../types/ObjectType";
-import { UserRequestOptions } from "../types/Params";
+import { WarrantRequestOptions } from "../types/WarrantRequestOptions";
 import { ListPricingTierOptions } from "../types/PricingTier";
 import { CreateTenantParams, ListTenantOptions, UpdateTenantParams } from "../types/Tenant";
 import { ListUserOptions } from "../types/User";
@@ -25,7 +25,7 @@ export default class Tenant implements WarrantObject {
     //
     // Static methods
     //
-    public static async create(tenant: CreateTenantParams = {}, options: UserRequestOptions = {}): Promise<Tenant> {
+    public static async create(tenant: CreateTenantParams = {}, options: WarrantRequestOptions = {}): Promise<Tenant> {
         try {
             const response = await WarrantClient.httpClient.post({
                 url: "/v1/tenants",
@@ -39,7 +39,7 @@ export default class Tenant implements WarrantObject {
         }
     }
 
-    public static async batchCreate(tenants: CreateTenantParams[], options: UserRequestOptions = {}): Promise<Tenant[]> {
+    public static async batchCreate(tenants: CreateTenantParams[], options: WarrantRequestOptions = {}): Promise<Tenant[]> {
         try {
             const response = await WarrantClient.httpClient.post({
                 url: "/v1/tenants",
@@ -53,7 +53,7 @@ export default class Tenant implements WarrantObject {
         }
     }
 
-    public static async get(tenantId: string, options: UserRequestOptions = {}): Promise<Tenant> {
+    public static async get(tenantId: string, options: WarrantRequestOptions = {}): Promise<Tenant> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/tenants/${tenantId}`,
@@ -66,7 +66,7 @@ export default class Tenant implements WarrantObject {
         }
     }
 
-    public static async update(tenantId: string, tenant: UpdateTenantParams, options: UserRequestOptions = {}): Promise<Tenant> {
+    public static async update(tenantId: string, tenant: UpdateTenantParams, options: WarrantRequestOptions = {}): Promise<Tenant> {
         try {
             const response = await WarrantClient.httpClient.put({
                 url: `/v1/tenants/${tenantId}`,
@@ -80,7 +80,7 @@ export default class Tenant implements WarrantObject {
         }
     }
 
-    public static async delete(tenantId: string, options: UserRequestOptions = {}): Promise<void> {
+    public static async delete(tenantId: string, options: WarrantRequestOptions = {}): Promise<void> {
         try {
             return await WarrantClient.httpClient.delete({
                 url: `/v1/tenants/${tenantId}`,
@@ -91,7 +91,7 @@ export default class Tenant implements WarrantObject {
         }
     }
 
-    public static async listTenants(listOptions: ListTenantOptions = {}, options: UserRequestOptions = {}): Promise<Tenant[]> {
+    public static async listTenants(listOptions: ListTenantOptions = {}, options: WarrantRequestOptions = {}): Promise<Tenant[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: "/v1/tenants",
@@ -105,7 +105,7 @@ export default class Tenant implements WarrantObject {
         }
     }
 
-    public static async listTenantsForUser(userId: string, listOptions: ListTenantOptions = {}, options: UserRequestOptions = {}): Promise<Tenant[]> {
+    public static async listTenantsForUser(userId: string, listOptions: ListTenantOptions = {}, options: WarrantRequestOptions = {}): Promise<Tenant[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/users/${userId}/tenants`,
@@ -122,43 +122,43 @@ export default class Tenant implements WarrantObject {
     //
     // Instance methods
     //
-    public async listUsers(listOptions: ListUserOptions = {}, options: UserRequestOptions = {}): Promise<User[]> {
+    public async listUsers(listOptions: ListUserOptions = {}, options: WarrantRequestOptions = {}): Promise<User[]> {
         return User.listUsersForTenant(this.tenantId, listOptions, options);
     }
 
-    public async assignUser(userId: string, role: string, options: UserRequestOptions = {}): Promise<Warrant> {
+    public async assignUser(userId: string, role: string, options: WarrantRequestOptions = {}): Promise<Warrant> {
         return User.assignUserToTenant(this.tenantId, userId, role, options);
     }
 
-    public async removeUser(userId: string, role: string, options: UserRequestOptions = {}): Promise<void> {
+    public async removeUser(userId: string, role: string, options: WarrantRequestOptions = {}): Promise<void> {
         return User.removeUserFromTenant(this.tenantId, userId, role, options);
     }
 
-    public async listPricingTiers(listOptions: ListPricingTierOptions = {}, options: UserRequestOptions = {}): Promise<PricingTier[]> {
+    public async listPricingTiers(listOptions: ListPricingTierOptions = {}, options: WarrantRequestOptions = {}): Promise<PricingTier[]> {
         return PricingTier.listPricingTiersForTenant(this.tenantId, listOptions, options);
     }
 
-    public async assignPricingTier(pricingTierId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+    public async assignPricingTier(pricingTierId: string, options: WarrantRequestOptions = {}): Promise<Warrant> {
         return PricingTier.assignPricingTierToTenant(this.tenantId, pricingTierId, options);
     }
 
-    public async removePricingTier(pricingTierId: string, options: UserRequestOptions = {}): Promise<void> {
+    public async removePricingTier(pricingTierId: string, options: WarrantRequestOptions = {}): Promise<void> {
         return PricingTier.removePricingTierFromTenant(this.tenantId, pricingTierId, options);
     }
 
-    public async listFeatures(listOptions: ListFeatureOptions = {}, options: UserRequestOptions = {}): Promise<Feature[]> {
+    public async listFeatures(listOptions: ListFeatureOptions = {}, options: WarrantRequestOptions = {}): Promise<Feature[]> {
         return Feature.listFeaturesForTenant(this.tenantId, listOptions, options);
     }
 
-    public async assignFeature(featureId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+    public async assignFeature(featureId: string, options: WarrantRequestOptions = {}): Promise<Warrant> {
         return Feature.assignFeatureToTenant(this.tenantId, featureId, options);
     }
 
-    public async removeFeature(featureId: string, options: UserRequestOptions = {}): Promise<void> {
+    public async removeFeature(featureId: string, options: WarrantRequestOptions = {}): Promise<void> {
         return Feature.removeFeatureFromTenant(this.tenantId, featureId, options);
     }
 
-    public async hasFeature(featureId: string, context: PolicyContext = {}, options: UserRequestOptions = {}): Promise<boolean> {
+    public async hasFeature(featureId: string, context: PolicyContext = {}, options: WarrantRequestOptions = {}): Promise<boolean> {
         return Authorization.hasFeature({ featureId: featureId, subject: { objectType: ObjectType.Tenant, objectId: this.tenantId }, context: context }, options);
     }
 

--- a/src/modules/Tenant.ts
+++ b/src/modules/Tenant.ts
@@ -6,6 +6,7 @@ import WarrantClient from "../WarrantClient";
 import Warrant from "./WarrantModule";
 import { ListFeatureOptions } from "../types/Feature";
 import { ObjectType } from "../types/ObjectType";
+import { UserRequestOptions } from "../types/Params";
 import { ListPricingTierOptions } from "../types/PricingTier";
 import { CreateTenantParams, ListTenantOptions, UpdateTenantParams } from "../types/Tenant";
 import { ListUserOptions } from "../types/User";
@@ -24,11 +25,12 @@ export default class Tenant implements WarrantObject {
     //
     // Static methods
     //
-    public static async create(tenant: CreateTenantParams = {}): Promise<Tenant> {
+    public static async create(tenant: CreateTenantParams = {}, options: UserRequestOptions = {}): Promise<Tenant> {
         try {
             const response = await WarrantClient.httpClient.post({
                 url: "/v1/tenants",
                 data: tenant,
+                options,
             });
 
             return new Tenant(response.tenantId, response.name);
@@ -37,11 +39,12 @@ export default class Tenant implements WarrantObject {
         }
     }
 
-    public static async batchCreate(tenants: CreateTenantParams[]): Promise<Tenant[]> {
+    public static async batchCreate(tenants: CreateTenantParams[], options: UserRequestOptions = {}): Promise<Tenant[]> {
         try {
             const response = await WarrantClient.httpClient.post({
                 url: "/v1/tenants",
                 data: tenants,
+                options,
             });
 
             return response.map((tenant: Tenant) => new Tenant(tenant.tenantId, tenant.name));
@@ -50,10 +53,11 @@ export default class Tenant implements WarrantObject {
         }
     }
 
-    public static async get(tenantId: string): Promise<Tenant> {
+    public static async get(tenantId: string, options: UserRequestOptions = {}): Promise<Tenant> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/tenants/${tenantId}`,
+                options,
             });
 
             return new Tenant(response.tenantId, response.name);
@@ -62,11 +66,12 @@ export default class Tenant implements WarrantObject {
         }
     }
 
-    public static async update(tenantId: string, tenant: UpdateTenantParams): Promise<Tenant> {
+    public static async update(tenantId: string, tenant: UpdateTenantParams, options: UserRequestOptions = {}): Promise<Tenant> {
         try {
             const response = await WarrantClient.httpClient.put({
                 url: `/v1/tenants/${tenantId}`,
                 data: tenant,
+                options,
             });
 
             return new Tenant(response.tenantId, response.name);
@@ -75,21 +80,23 @@ export default class Tenant implements WarrantObject {
         }
     }
 
-    public static async delete(tenantId: string): Promise<void> {
+    public static async delete(tenantId: string, options: UserRequestOptions = {}): Promise<void> {
         try {
             return await WarrantClient.httpClient.delete({
                 url: `/v1/tenants/${tenantId}`,
+                options,
             });
         } catch (e) {
             throw e;
         }
     }
 
-    public static async listTenants(listOptions: ListTenantOptions = {}): Promise<Tenant[]> {
+    public static async listTenants(listOptions: ListTenantOptions = {}, options: UserRequestOptions = {}): Promise<Tenant[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: "/v1/tenants",
                 params: listOptions,
+                options,
             });
 
             return response.map((tenant: Tenant) => new Tenant(tenant.tenantId, tenant.name));
@@ -98,11 +105,12 @@ export default class Tenant implements WarrantObject {
         }
     }
 
-    public static async listTenantsForUser(userId: string, listOptions: ListTenantOptions = {}): Promise<Tenant[]> {
+    public static async listTenantsForUser(userId: string, listOptions: ListTenantOptions = {}, options: UserRequestOptions = {}): Promise<Tenant[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/users/${userId}/tenants`,
                 params: listOptions,
+                options,
             });
 
             return response.map((tenant: Tenant) => new Tenant(tenant.tenantId, tenant.name));
@@ -114,44 +122,44 @@ export default class Tenant implements WarrantObject {
     //
     // Instance methods
     //
-    public async listUsers(listOptions: ListUserOptions = {}): Promise<User[]> {
-        return User.listUsersForTenant(this.tenantId, listOptions);
+    public async listUsers(listOptions: ListUserOptions = {}, options: UserRequestOptions = {}): Promise<User[]> {
+        return User.listUsersForTenant(this.tenantId, listOptions, options);
     }
 
-    public async assignUser(userId: string, role: string): Promise<Warrant> {
-        return User.assignUserToTenant(this.tenantId, userId, role);
+    public async assignUser(userId: string, role: string, options: UserRequestOptions = {}): Promise<Warrant> {
+        return User.assignUserToTenant(this.tenantId, userId, role, options);
     }
 
-    public async removeUser(userId: string, role: string): Promise<void> {
-        return User.removeUserFromTenant(this.tenantId, userId, role);
+    public async removeUser(userId: string, role: string, options: UserRequestOptions = {}): Promise<void> {
+        return User.removeUserFromTenant(this.tenantId, userId, role, options);
     }
 
-    public async listPricingTiers(listOptions: ListPricingTierOptions = {}): Promise<PricingTier[]> {
-        return PricingTier.listPricingTiersForTenant(this.tenantId, listOptions);
+    public async listPricingTiers(listOptions: ListPricingTierOptions = {}, options: UserRequestOptions = {}): Promise<PricingTier[]> {
+        return PricingTier.listPricingTiersForTenant(this.tenantId, listOptions, options);
     }
 
-    public async assignPricingTier(pricingTierId: string): Promise<Warrant> {
-        return PricingTier.assignPricingTierToTenant(this.tenantId, pricingTierId);
+    public async assignPricingTier(pricingTierId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+        return PricingTier.assignPricingTierToTenant(this.tenantId, pricingTierId, options);
     }
 
-    public async removePricingTier(pricingTierId: string): Promise<void> {
-        return PricingTier.removePricingTierFromTenant(this.tenantId, pricingTierId);
+    public async removePricingTier(pricingTierId: string, options: UserRequestOptions = {}): Promise<void> {
+        return PricingTier.removePricingTierFromTenant(this.tenantId, pricingTierId, options);
     }
 
-    public async listFeatures(listOptions: ListFeatureOptions = {}): Promise<Feature[]> {
-        return Feature.listFeaturesForTenant(this.tenantId, listOptions);
+    public async listFeatures(listOptions: ListFeatureOptions = {}, options: UserRequestOptions = {}): Promise<Feature[]> {
+        return Feature.listFeaturesForTenant(this.tenantId, listOptions, options);
     }
 
-    public async assignFeature(featureId: string): Promise<Warrant> {
-        return Feature.assignFeatureToTenant(this.tenantId, featureId);
+    public async assignFeature(featureId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+        return Feature.assignFeatureToTenant(this.tenantId, featureId, options);
     }
 
-    public async removeFeature(featureId: string): Promise<void> {
-        return Feature.removeFeatureFromTenant(this.tenantId, featureId);
+    public async removeFeature(featureId: string, options: UserRequestOptions = {}): Promise<void> {
+        return Feature.removeFeatureFromTenant(this.tenantId, featureId, options);
     }
 
-    public async hasFeature(featureId: string, context: PolicyContext = {}): Promise<boolean> {
-        return Authorization.hasFeature({ featureId: featureId, subject: { objectType: ObjectType.Tenant, objectId: this.tenantId }, context: context });
+    public async hasFeature(featureId: string, context: PolicyContext = {}, options: UserRequestOptions = {}): Promise<boolean> {
+        return Authorization.hasFeature({ featureId: featureId, subject: { objectType: ObjectType.Tenant, objectId: this.tenantId }, context: context }, options);
     }
 
     // WarrantObject methods

--- a/src/modules/User.ts
+++ b/src/modules/User.ts
@@ -8,6 +8,7 @@ import WarrantClient from "../WarrantClient";
 import Warrant from "./WarrantModule";
 import { ListFeatureOptions } from "../types/Feature";
 import { ObjectType } from "../types/ObjectType";
+import { UserRequestOptions } from "../types/Params";
 import { ListPermissionOptions } from "../types/Permission";
 import { ListPricingTierOptions } from "../types/PricingTier";
 import { ListRoleOptions } from "../types/Role";
@@ -28,11 +29,12 @@ export default class User implements WarrantObject {
     //
     // Static methods
     //
-    public static async create(user: CreateUserParams = {}): Promise<User> {
+    public static async create(user: CreateUserParams = {}, options: UserRequestOptions = {}): Promise<User> {
         try {
             const response = await WarrantClient.httpClient.post({
                 url: "/v1/users",
                 data: user,
+                options,
             });
 
             return new User(response.userId, response.email);
@@ -41,11 +43,12 @@ export default class User implements WarrantObject {
         }
     }
 
-    public static async batchCreate(users: CreateUserParams[]): Promise<User[]> {
+    public static async batchCreate(users: CreateUserParams[], options: UserRequestOptions = {}): Promise<User[]> {
         try {
             const response = await WarrantClient.httpClient.post({
                 url: "/v1/users",
                 data: users,
+                options,
             });
 
             return response.map((user: User) => new User(user.userId, user.email));
@@ -54,10 +57,11 @@ export default class User implements WarrantObject {
         }
     }
 
-    public static async get(userId: string): Promise<User> {
+    public static async get(userId: string, options: UserRequestOptions = {}): Promise<User> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/users/${userId}`,
+                options,
             });
 
             return new User(response.userId, response.email);
@@ -66,11 +70,12 @@ export default class User implements WarrantObject {
         }
     }
 
-    public static async update(userId: string, user: UpdateUserParams): Promise<User> {
+    public static async update(userId: string, user: UpdateUserParams, options: UserRequestOptions = {}): Promise<User> {
         try {
             const response = await WarrantClient.httpClient.put({
                 url: `/v1/users/${userId}`,
                 data: user,
+                options,
             });
 
             return new User(response.userId, response.email);
@@ -79,21 +84,23 @@ export default class User implements WarrantObject {
         }
     }
 
-    public static async delete(userId: string): Promise<void> {
+    public static async delete(userId: string, options: UserRequestOptions = {}): Promise<void> {
         try {
             return await WarrantClient.httpClient.delete({
                 url: `/v1/users/${userId}`,
+                options,
             });
         } catch (e) {
             throw e;
         }
     }
 
-    public static async listUsers(listOptions: ListUserOptions = {}): Promise<User[]> {
+    public static async listUsers(listOptions: ListUserOptions = {}, options: UserRequestOptions = {}): Promise<User[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: "/v1/users",
                 params: listOptions,
+                options,
             });
 
             return response.map((user: User) => new User(user.userId, user.email));
@@ -102,11 +109,12 @@ export default class User implements WarrantObject {
         }
     }
 
-    public static async listUsersForTenant(tenantId: string, listOptions: ListUserOptions = {}): Promise<User[]> {
+    public static async listUsersForTenant(tenantId: string, listOptions: ListUserOptions = {}, options: UserRequestOptions = {}): Promise<User[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/tenants/${tenantId}/users`,
                 params: listOptions,
+                options,
             });
 
             return response.map((user: User) => new User(user.userId, user.email));
@@ -115,7 +123,7 @@ export default class User implements WarrantObject {
         }
     }
 
-    public static async assignUserToTenant(tenantId: string, userId: string, role: string): Promise<Warrant> {
+    public static async assignUserToTenant(tenantId: string, userId: string, role: string, options: UserRequestOptions = {}): Promise<Warrant> {
         return WarrantModule.create({
             object: {
                 objectType: ObjectType.Tenant,
@@ -126,10 +134,10 @@ export default class User implements WarrantObject {
                 objectType: ObjectType.User,
                 objectId: userId,
             }
-        });
+        }, options);
     }
 
-    public static async removeUserFromTenant(tenantId: string, userId: string, role: string): Promise<void> {
+    public static async removeUserFromTenant(tenantId: string, userId: string, role: string, options: UserRequestOptions = {}): Promise<void> {
         return WarrantModule.delete({
             object: {
                 objectType: ObjectType.Tenant,
@@ -140,70 +148,70 @@ export default class User implements WarrantObject {
                 objectType: ObjectType.User,
                 objectId: userId,
             }
-        });
+        }, options);
     }
 
     //
     // Instance methods
     //
-    public async listTenants(listOptions: ListTenantOptions = {}): Promise<Tenant[]> {
-        return Tenant.listTenantsForUser(this.userId, listOptions);
+    public async listTenants(listOptions: ListTenantOptions = {}, options: UserRequestOptions = {}): Promise<Tenant[]> {
+        return Tenant.listTenantsForUser(this.userId, listOptions, options);
     }
 
-    public async listRoles(listOptions: ListRoleOptions = {}): Promise<Role[]> {
-        return Role.listRolesForUser(this.userId, listOptions);
+    public async listRoles(listOptions: ListRoleOptions = {}, options: UserRequestOptions = {}): Promise<Role[]> {
+        return Role.listRolesForUser(this.userId, listOptions, options);
     }
 
-    public async assignRole(roleId: string): Promise<Warrant> {
-        return Role.assignRoleToUser(this.userId, roleId);
+    public async assignRole(roleId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+        return Role.assignRoleToUser(this.userId, roleId, options);
     }
 
-    public async removeRole(roleId: string): Promise<void> {
-        return Role.removeRoleFromUser(this.userId, roleId);
+    public async removeRole(roleId: string, options: UserRequestOptions = {}): Promise<void> {
+        return Role.removeRoleFromUser(this.userId, roleId, options);
     }
 
-    public async listPermissions(listOptions: ListPermissionOptions = {}): Promise<Permission[]> {
-        return Permission.listPermissionsForUser(this.userId, listOptions);
+    public async listPermissions(listOptions: ListPermissionOptions = {}, options: UserRequestOptions = {}): Promise<Permission[]> {
+        return Permission.listPermissionsForUser(this.userId, listOptions, options);
     }
 
-    public async assignPermission(permissionId: string): Promise<Warrant> {
-        return Permission.assignPermissionToUser(this.userId, permissionId);
+    public async assignPermission(permissionId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+        return Permission.assignPermissionToUser(this.userId, permissionId, options);
     }
 
-    public async removePermission(permissionId: string): Promise<void> {
-        return Permission.removePermissionFromUser(this.userId, permissionId);
+    public async removePermission(permissionId: string, options: UserRequestOptions = {}): Promise<void> {
+        return Permission.removePermissionFromUser(this.userId, permissionId, options);
     }
 
-    public async hasPermission(permissionId: string, context: PolicyContext = {}): Promise<boolean> {
-        return Authorization.hasPermission({ permissionId: permissionId, subject: { objectType: ObjectType.User, objectId: this.userId }, context: context });
+    public async hasPermission(permissionId: string, context: PolicyContext = {}, options: UserRequestOptions = {}): Promise<boolean> {
+        return Authorization.hasPermission({ permissionId: permissionId, subject: { objectType: ObjectType.User, objectId: this.userId }, context: context }, options);
     }
 
-    public async listPricingTiers(listOptions: ListPricingTierOptions = {}): Promise<PricingTier[]> {
-        return PricingTier.listPricingTiersForUser(this.userId, listOptions);
+    public async listPricingTiers(listOptions: ListPricingTierOptions = {}, options: UserRequestOptions = {}): Promise<PricingTier[]> {
+        return PricingTier.listPricingTiersForUser(this.userId, listOptions, options);
     }
 
-    public async assignPricingTier(pricingTierId: string): Promise<Warrant> {
-        return PricingTier.assignPricingTierToUser(this.userId, pricingTierId);
+    public async assignPricingTier(pricingTierId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+        return PricingTier.assignPricingTierToUser(this.userId, pricingTierId, options);
     }
 
-    public async removePricingTier(pricingTierId: string): Promise<void> {
-        return PricingTier.removePricingTierFromUser(this.userId, pricingTierId);
+    public async removePricingTier(pricingTierId: string, options: UserRequestOptions = {}): Promise<void> {
+        return PricingTier.removePricingTierFromUser(this.userId, pricingTierId, options);
     }
 
-    public async listFeatures(listOptions: ListFeatureOptions = {}): Promise<Feature[]> {
-        return Feature.listFeaturesForUser(this.userId, listOptions);
+    public async listFeatures(listOptions: ListFeatureOptions = {}, options: UserRequestOptions = {}): Promise<Feature[]> {
+        return Feature.listFeaturesForUser(this.userId, listOptions, options);
     }
 
-    public async assignFeature(featureId: string): Promise<Warrant> {
-        return Feature.assignFeatureToUser(this.userId, featureId);
+    public async assignFeature(featureId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+        return Feature.assignFeatureToUser(this.userId, featureId, options);
     }
 
-    public async removeFeature(featureId: string): Promise<void> {
-        return Feature.removeFeatureFromUser(this.userId, featureId);
+    public async removeFeature(featureId: string, options: UserRequestOptions = {}): Promise<void> {
+        return Feature.removeFeatureFromUser(this.userId, featureId, options);
     }
 
-    public async hasFeature(featureId: string, context: PolicyContext = {}): Promise<boolean> {
-        return Authorization.hasFeature({ featureId: featureId, subject: { objectType: ObjectType.User, objectId: this.userId }, context: context });
+    public async hasFeature(featureId: string, context: PolicyContext = {}, options: UserRequestOptions = {}): Promise<boolean> {
+        return Authorization.hasFeature({ featureId: featureId, subject: { objectType: ObjectType.User, objectId: this.userId }, context: context }, options);
     }
 
     // WarrantObject methods

--- a/src/modules/User.ts
+++ b/src/modules/User.ts
@@ -8,7 +8,7 @@ import WarrantClient from "../WarrantClient";
 import Warrant from "./WarrantModule";
 import { ListFeatureOptions } from "../types/Feature";
 import { ObjectType } from "../types/ObjectType";
-import { UserRequestOptions } from "../types/Params";
+import { WarrantRequestOptions } from "../types/WarrantRequestOptions";
 import { ListPermissionOptions } from "../types/Permission";
 import { ListPricingTierOptions } from "../types/PricingTier";
 import { ListRoleOptions } from "../types/Role";
@@ -29,7 +29,7 @@ export default class User implements WarrantObject {
     //
     // Static methods
     //
-    public static async create(user: CreateUserParams = {}, options: UserRequestOptions = {}): Promise<User> {
+    public static async create(user: CreateUserParams = {}, options: WarrantRequestOptions = {}): Promise<User> {
         try {
             const response = await WarrantClient.httpClient.post({
                 url: "/v1/users",
@@ -43,7 +43,7 @@ export default class User implements WarrantObject {
         }
     }
 
-    public static async batchCreate(users: CreateUserParams[], options: UserRequestOptions = {}): Promise<User[]> {
+    public static async batchCreate(users: CreateUserParams[], options: WarrantRequestOptions = {}): Promise<User[]> {
         try {
             const response = await WarrantClient.httpClient.post({
                 url: "/v1/users",
@@ -57,7 +57,7 @@ export default class User implements WarrantObject {
         }
     }
 
-    public static async get(userId: string, options: UserRequestOptions = {}): Promise<User> {
+    public static async get(userId: string, options: WarrantRequestOptions = {}): Promise<User> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/users/${userId}`,
@@ -70,7 +70,7 @@ export default class User implements WarrantObject {
         }
     }
 
-    public static async update(userId: string, user: UpdateUserParams, options: UserRequestOptions = {}): Promise<User> {
+    public static async update(userId: string, user: UpdateUserParams, options: WarrantRequestOptions = {}): Promise<User> {
         try {
             const response = await WarrantClient.httpClient.put({
                 url: `/v1/users/${userId}`,
@@ -84,7 +84,7 @@ export default class User implements WarrantObject {
         }
     }
 
-    public static async delete(userId: string, options: UserRequestOptions = {}): Promise<void> {
+    public static async delete(userId: string, options: WarrantRequestOptions = {}): Promise<void> {
         try {
             return await WarrantClient.httpClient.delete({
                 url: `/v1/users/${userId}`,
@@ -95,7 +95,7 @@ export default class User implements WarrantObject {
         }
     }
 
-    public static async listUsers(listOptions: ListUserOptions = {}, options: UserRequestOptions = {}): Promise<User[]> {
+    public static async listUsers(listOptions: ListUserOptions = {}, options: WarrantRequestOptions = {}): Promise<User[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: "/v1/users",
@@ -109,7 +109,7 @@ export default class User implements WarrantObject {
         }
     }
 
-    public static async listUsersForTenant(tenantId: string, listOptions: ListUserOptions = {}, options: UserRequestOptions = {}): Promise<User[]> {
+    public static async listUsersForTenant(tenantId: string, listOptions: ListUserOptions = {}, options: WarrantRequestOptions = {}): Promise<User[]> {
         try {
             const response = await WarrantClient.httpClient.get({
                 url: `/v1/tenants/${tenantId}/users`,
@@ -123,7 +123,7 @@ export default class User implements WarrantObject {
         }
     }
 
-    public static async assignUserToTenant(tenantId: string, userId: string, role: string, options: UserRequestOptions = {}): Promise<Warrant> {
+    public static async assignUserToTenant(tenantId: string, userId: string, role: string, options: WarrantRequestOptions = {}): Promise<Warrant> {
         return WarrantModule.create({
             object: {
                 objectType: ObjectType.Tenant,
@@ -137,7 +137,7 @@ export default class User implements WarrantObject {
         }, options);
     }
 
-    public static async removeUserFromTenant(tenantId: string, userId: string, role: string, options: UserRequestOptions = {}): Promise<void> {
+    public static async removeUserFromTenant(tenantId: string, userId: string, role: string, options: WarrantRequestOptions = {}): Promise<void> {
         return WarrantModule.delete({
             object: {
                 objectType: ObjectType.Tenant,
@@ -154,63 +154,63 @@ export default class User implements WarrantObject {
     //
     // Instance methods
     //
-    public async listTenants(listOptions: ListTenantOptions = {}, options: UserRequestOptions = {}): Promise<Tenant[]> {
+    public async listTenants(listOptions: ListTenantOptions = {}, options: WarrantRequestOptions = {}): Promise<Tenant[]> {
         return Tenant.listTenantsForUser(this.userId, listOptions, options);
     }
 
-    public async listRoles(listOptions: ListRoleOptions = {}, options: UserRequestOptions = {}): Promise<Role[]> {
+    public async listRoles(listOptions: ListRoleOptions = {}, options: WarrantRequestOptions = {}): Promise<Role[]> {
         return Role.listRolesForUser(this.userId, listOptions, options);
     }
 
-    public async assignRole(roleId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+    public async assignRole(roleId: string, options: WarrantRequestOptions = {}): Promise<Warrant> {
         return Role.assignRoleToUser(this.userId, roleId, options);
     }
 
-    public async removeRole(roleId: string, options: UserRequestOptions = {}): Promise<void> {
+    public async removeRole(roleId: string, options: WarrantRequestOptions = {}): Promise<void> {
         return Role.removeRoleFromUser(this.userId, roleId, options);
     }
 
-    public async listPermissions(listOptions: ListPermissionOptions = {}, options: UserRequestOptions = {}): Promise<Permission[]> {
+    public async listPermissions(listOptions: ListPermissionOptions = {}, options: WarrantRequestOptions = {}): Promise<Permission[]> {
         return Permission.listPermissionsForUser(this.userId, listOptions, options);
     }
 
-    public async assignPermission(permissionId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+    public async assignPermission(permissionId: string, options: WarrantRequestOptions = {}): Promise<Warrant> {
         return Permission.assignPermissionToUser(this.userId, permissionId, options);
     }
 
-    public async removePermission(permissionId: string, options: UserRequestOptions = {}): Promise<void> {
+    public async removePermission(permissionId: string, options: WarrantRequestOptions = {}): Promise<void> {
         return Permission.removePermissionFromUser(this.userId, permissionId, options);
     }
 
-    public async hasPermission(permissionId: string, context: PolicyContext = {}, options: UserRequestOptions = {}): Promise<boolean> {
+    public async hasPermission(permissionId: string, context: PolicyContext = {}, options: WarrantRequestOptions = {}): Promise<boolean> {
         return Authorization.hasPermission({ permissionId: permissionId, subject: { objectType: ObjectType.User, objectId: this.userId }, context: context }, options);
     }
 
-    public async listPricingTiers(listOptions: ListPricingTierOptions = {}, options: UserRequestOptions = {}): Promise<PricingTier[]> {
+    public async listPricingTiers(listOptions: ListPricingTierOptions = {}, options: WarrantRequestOptions = {}): Promise<PricingTier[]> {
         return PricingTier.listPricingTiersForUser(this.userId, listOptions, options);
     }
 
-    public async assignPricingTier(pricingTierId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+    public async assignPricingTier(pricingTierId: string, options: WarrantRequestOptions = {}): Promise<Warrant> {
         return PricingTier.assignPricingTierToUser(this.userId, pricingTierId, options);
     }
 
-    public async removePricingTier(pricingTierId: string, options: UserRequestOptions = {}): Promise<void> {
+    public async removePricingTier(pricingTierId: string, options: WarrantRequestOptions = {}): Promise<void> {
         return PricingTier.removePricingTierFromUser(this.userId, pricingTierId, options);
     }
 
-    public async listFeatures(listOptions: ListFeatureOptions = {}, options: UserRequestOptions = {}): Promise<Feature[]> {
+    public async listFeatures(listOptions: ListFeatureOptions = {}, options: WarrantRequestOptions = {}): Promise<Feature[]> {
         return Feature.listFeaturesForUser(this.userId, listOptions, options);
     }
 
-    public async assignFeature(featureId: string, options: UserRequestOptions = {}): Promise<Warrant> {
+    public async assignFeature(featureId: string, options: WarrantRequestOptions = {}): Promise<Warrant> {
         return Feature.assignFeatureToUser(this.userId, featureId, options);
     }
 
-    public async removeFeature(featureId: string, options: UserRequestOptions = {}): Promise<void> {
+    public async removeFeature(featureId: string, options: WarrantRequestOptions = {}): Promise<void> {
         return Feature.removeFeatureFromUser(this.userId, featureId, options);
     }
 
-    public async hasFeature(featureId: string, context: PolicyContext = {}, options: UserRequestOptions = {}): Promise<boolean> {
+    public async hasFeature(featureId: string, context: PolicyContext = {}, options: WarrantRequestOptions = {}): Promise<boolean> {
         return Authorization.hasFeature({ featureId: featureId, subject: { objectType: ObjectType.User, objectId: this.userId }, context: context }, options);
     }
 

--- a/src/modules/WarrantModule.ts
+++ b/src/modules/WarrantModule.ts
@@ -1,9 +1,10 @@
 import WarrantClient from "../WarrantClient";
+import { UserRequestOptions } from "../types/Params";
 import Query from "../types/Query";
 import Warrant, { isSubject, isWarrantObject, ListWarrantOptions, WarrantParams } from "../types/Warrant";
 
 export default class WarrantModule {
-    public static async create(warrant: WarrantParams): Promise<Warrant> {
+    public static async create(warrant: WarrantParams, options: UserRequestOptions = {}): Promise<Warrant> {
         try {
             return await WarrantClient.httpClient.post({
                 url: "/v1/warrants",
@@ -14,13 +15,14 @@ export default class WarrantModule {
                     subject: isSubject(warrant.subject) ? warrant.subject : { objectType: warrant.subject.getObjectType(), objectId: warrant.subject.getObjectId() },
                     policy: warrant.policy
                 },
+                options,
             });
         } catch (e) {
             throw e;
         }
     }
 
-    public static async delete(warrant: WarrantParams): Promise<void> {
+    public static async delete(warrant: WarrantParams, options: UserRequestOptions = {}): Promise<void> {
         try {
             return await WarrantClient.httpClient.delete({
                 url: "/v1/warrants",
@@ -31,13 +33,14 @@ export default class WarrantModule {
                     subject: isSubject(warrant.subject) ? warrant.subject : { objectType: warrant.subject.getObjectType(), objectId: warrant.subject.getObjectId() },
                     policy: warrant.policy
                 },
+                options,
             });
         } catch (e) {
             throw e;
         }
     }
 
-    public static async queryWarrants(query: Query, listOptions: ListWarrantOptions = {}): Promise<Warrant[]> {
+    public static async queryWarrants(query: Query, listOptions: ListWarrantOptions = {}, options: UserRequestOptions = {}): Promise<Warrant[]> {
         try {
             return await WarrantClient.httpClient.get({
                 url: "/v1/query",
@@ -45,6 +48,7 @@ export default class WarrantModule {
                     ...query.toObject(),
                     ...listOptions
                 },
+                options,
             });
         } catch (e) {
             throw e;

--- a/src/modules/WarrantModule.ts
+++ b/src/modules/WarrantModule.ts
@@ -1,10 +1,10 @@
 import WarrantClient from "../WarrantClient";
-import { UserRequestOptions } from "../types/Params";
+import { WarrantRequestOptions } from "../types/WarrantRequestOptions";
 import Query from "../types/Query";
 import Warrant, { isSubject, isWarrantObject, ListWarrantOptions, WarrantParams } from "../types/Warrant";
 
 export default class WarrantModule {
-    public static async create(warrant: WarrantParams, options: UserRequestOptions = {}): Promise<Warrant> {
+    public static async create(warrant: WarrantParams, options: WarrantRequestOptions = {}): Promise<Warrant> {
         try {
             return await WarrantClient.httpClient.post({
                 url: "/v1/warrants",
@@ -22,7 +22,7 @@ export default class WarrantModule {
         }
     }
 
-    public static async delete(warrant: WarrantParams, options: UserRequestOptions = {}): Promise<void> {
+    public static async delete(warrant: WarrantParams, options: WarrantRequestOptions = {}): Promise<void> {
         try {
             return await WarrantClient.httpClient.delete({
                 url: "/v1/warrants",
@@ -40,7 +40,7 @@ export default class WarrantModule {
         }
     }
 
-    public static async queryWarrants(query: Query, listOptions: ListWarrantOptions = {}, options: UserRequestOptions = {}): Promise<Warrant[]> {
+    public static async queryWarrants(query: Query, listOptions: ListWarrantOptions = {}, options: WarrantRequestOptions = {}): Promise<Warrant[]> {
         try {
             return await WarrantClient.httpClient.get({
                 url: "/v1/query",

--- a/src/types/Params.ts
+++ b/src/types/Params.ts
@@ -1,3 +1,0 @@
-export interface UserRequestOptions {
-    warrantToken?: string;
-}

--- a/src/types/Params.ts
+++ b/src/types/Params.ts
@@ -1,0 +1,3 @@
+export interface UserRequestOptions {
+    warrantToken?: string;
+}

--- a/src/types/WarrantRequestOptions.ts
+++ b/src/types/WarrantRequestOptions.ts
@@ -1,0 +1,3 @@
+export interface WarrantRequestOptions {
+    warrantToken?: string;
+}

--- a/test/LiveTest.spec.js
+++ b/test/LiveTest.spec.js
@@ -543,7 +543,7 @@ describe.skip('Live Test', function () {
         await this.warrant.Permission.delete(newPermission.permissionId);
     });
 
-    it.only('warrant with policy', async function() {
+    it('warrant with policy', async function() {
         await this.warrant.Warrant.create({
             object: {
                 objectType: "permission",

--- a/test/LiveTest.spec.js
+++ b/test/LiveTest.spec.js
@@ -13,21 +13,21 @@ describe.skip('Live Test', function () {
         assert.equal(user1.email, null);
 
         let user2 = await this.warrant.User.create({ userId: "some_id", email: "test@email.com" });
-        let refetchedUser = await this.warrant.User.get(user2.userId);
+        let refetchedUser = await this.warrant.User.get(user2.userId, { warrantToken: "latest" });
         assert.strictEqual(user2.userId, refetchedUser.userId);
         assert.strictEqual(user2.email, refetchedUser.email);
 
         user2 = await this.warrant.User.update("some_id", { email: "updated@email.com" });
-        refetchedUser = await this.warrant.User.get("some_id");
+        refetchedUser = await this.warrant.User.get("some_id", { warrantToken: "latest" });
         assert.strictEqual(refetchedUser.userId, "some_id");
         assert.strictEqual(refetchedUser.email, "updated@email.com");
 
-        let users = await this.warrant.User.listUsers({ limit: 10 });
+        let users = await this.warrant.User.listUsers({ limit: 10 }, { warrantToken: "latest" });
         assert.strictEqual(users.length, 2);
 
         await this.warrant.User.delete(user1.userId);
         await this.warrant.User.delete(user2.userId);
-        users = await this.warrant.User.listUsers({ limit: 10 });
+        users = await this.warrant.User.listUsers({ limit: 10 }, { warrantToken: "latest" });
         assert.strictEqual(users.length, 0);
     });
 
@@ -37,21 +37,21 @@ describe.skip('Live Test', function () {
         assert.equal(tenant1.name, null);
 
         let tenant2 = await this.warrant.Tenant.create({ tenantId: "some_tenant_id", name: "new_name" });
-        let refetchedTenant = await this.warrant.Tenant.get(tenant2.tenantId);
+        let refetchedTenant = await this.warrant.Tenant.get(tenant2.tenantId, { warrantToken: "latest" });
         assert.strictEqual(tenant2.tenantId, refetchedTenant.tenantId);
         assert.strictEqual(tenant2.name, refetchedTenant.name);
 
         tenant2 = await this.warrant.Tenant.update("some_tenant_id", { name: "updated_name" });
-        refetchedTenant = await this.warrant.Tenant.get("some_tenant_id");
+        refetchedTenant = await this.warrant.Tenant.get("some_tenant_id", { warrantToken: "latest" });
         assert.strictEqual(refetchedTenant.tenantId, "some_tenant_id");
         assert.strictEqual(refetchedTenant.name, "updated_name");
 
-        let tenants = await this.warrant.Tenant.listTenants({ limit: 10 });
+        let tenants = await this.warrant.Tenant.listTenants({ limit: 10 }, { warrantToken: "latest" });
         assert.strictEqual(tenants.length, 2);
 
         await this.warrant.Tenant.delete(tenant1.tenantId);
         await this.warrant.Tenant.delete(tenant2.tenantId);
-        tenants = await this.warrant.Tenant.listTenants({ limit: 10 });
+        tenants = await this.warrant.Tenant.listTenants({ limit: 10 }, { warrantToken: "latest" });
         assert.strictEqual(tenants.length, 0);
     });
 
@@ -62,23 +62,23 @@ describe.skip('Live Test', function () {
         assert.strictEqual(adminRole.description, "The admin role");
 
         let viewerRole = await this.warrant.Role.create({ roleId: "viewer", name: "Viewer", description: "The viewer role" });
-        let refetchedRole = await this.warrant.Role.get(viewerRole.roleId);
+        let refetchedRole = await this.warrant.Role.get(viewerRole.roleId, { warrantToken: "latest" });
         assert.strictEqual(viewerRole.roleId, refetchedRole.roleId);
         assert.strictEqual(viewerRole.name, refetchedRole.name);
         assert.strictEqual(viewerRole.description, refetchedRole.description);
 
         viewerRole = await this.warrant.Role.update("viewer", { name: "Viewer Updated", description: "Updated desc" });
-        refetchedRole = await this.warrant.Role.get("viewer");
+        refetchedRole = await this.warrant.Role.get("viewer", { warrantToken: "latest" });
         assert.strictEqual(refetchedRole.roleId, "viewer");
         assert.strictEqual(refetchedRole.name, "Viewer Updated");
         assert.strictEqual(refetchedRole.description, "Updated desc");
 
-        let roles = await this.warrant.Role.listRoles({ limit: 10 });
+        let roles = await this.warrant.Role.listRoles({ limit: 10 }, { warrantToken: "latest" });
         assert.strictEqual(roles.length, 2);
 
         await this.warrant.Role.delete(adminRole.roleId);
         await this.warrant.Role.delete(viewerRole.roleId);
-        roles = await this.warrant.Role.listRoles({ limit: 10 });
+        roles = await this.warrant.Role.listRoles({ limit: 10 }, { warrantToken: "latest" });
         assert.strictEqual(roles.length, 0);
     });
 
@@ -89,23 +89,23 @@ describe.skip('Live Test', function () {
         assert.strictEqual(permission1.description, "Permission with id 1");
 
         let permission2 = await this.warrant.Permission.create({ permissionId: "perm2", name: "Permission 2", description: "Permission with id 2" });
-        let refetchedPermission = await this.warrant.Permission.get(permission2.permissionId);
+        let refetchedPermission = await this.warrant.Permission.get(permission2.permissionId, { warrantToken: "latest" });
         assert.strictEqual(permission2.permissionId, refetchedPermission.permissionId);
         assert.strictEqual(permission2.name, refetchedPermission.name);
         assert.strictEqual(permission2.description, refetchedPermission.description);
 
         permission2 = await this.warrant.Permission.update("perm2", { name: "Permission 2 Updated", description: "Updated desc" });
-        refetchedPermission = await this.warrant.Permission.get("perm2");
+        refetchedPermission = await this.warrant.Permission.get("perm2", { warrantToken: "latest" });
         assert.strictEqual(refetchedPermission.permissionId, "perm2");
         assert.strictEqual(refetchedPermission.name, "Permission 2 Updated");
         assert.strictEqual(refetchedPermission.description, "Updated desc");
 
-        let permissions = await this.warrant.Permission.listPermissions({ limit: 10 });
+        let permissions = await this.warrant.Permission.listPermissions({ limit: 10 }, { warrantToken: "latest" });
         assert.strictEqual(permissions.length, 2);
 
         await this.warrant.Permission.delete(permission1.permissionId);
         await this.warrant.Permission.delete(permission2.permissionId);
-        permissions = await this.warrant.Permission.listPermissions({ limit: 10 });
+        permissions = await this.warrant.Permission.listPermissions({ limit: 10 }, { warrantToken: "latest" });
         assert.strictEqual(permissions.length, 0);
     });
 
@@ -114,15 +114,15 @@ describe.skip('Live Test', function () {
         assert.strictEqual(feature1.featureId, "new-feature");
 
         const feature2 = await this.warrant.Feature.create({ featureId: "feature-2" });
-        const refetchedFeature = await this.warrant.Feature.get(feature2.featureId);
+        const refetchedFeature = await this.warrant.Feature.get(feature2.featureId, { warrantToken: "latest" });
         assert.strictEqual(feature2.featureId, refetchedFeature.featureId);
 
-        let features = await this.warrant.Feature.listFeatures({ limit: 10 });
+        let features = await this.warrant.Feature.listFeatures({ limit: 10 }, { warrantToken: "latest" });
         assert.strictEqual(features.length, 2);
 
         await this.warrant.Feature.delete(feature1.featureId);
         await this.warrant.Feature.delete(feature2.featureId);
-        features = await this.warrant.Feature.listFeatures({ limit: 10 });
+        features = await this.warrant.Feature.listFeatures({ limit: 10 }, { warrantToken: "latest" });
         assert.strictEqual(features.length, 0);
     });
 
@@ -131,15 +131,15 @@ describe.skip('Live Test', function () {
         assert.strictEqual(tier1.pricingTierId, "new-tier-1");
 
         const tier2 = await this.warrant.PricingTier.create({ pricingTierId: "tier-2" });
-        const refetchedTier = await this.warrant.PricingTier.get(tier2.pricingTierId);
+        const refetchedTier = await this.warrant.PricingTier.get(tier2.pricingTierId, { warrantToken: "latest" });
         assert.strictEqual(tier2.pricingTierId, refetchedTier.pricingTierId);
 
-        let tiers = await this.warrant.PricingTier.listPricingTiers({ limit: 10 });
+        let tiers = await this.warrant.PricingTier.listPricingTiers({ limit: 10 }, { warrantToken: "latest" });
         assert.strictEqual(tiers.length, 2);
 
         await this.warrant.PricingTier.delete(tier1.pricingTierId);
         await this.warrant.PricingTier.delete(tier2.pricingTierId);
-        tiers = await this.warrant.PricingTier.listPricingTiers({ limit: 10 });
+        tiers = await this.warrant.PricingTier.listPricingTiers({ limit: 10 }, { warrantToken: "latest" });
         assert.strictEqual(tiers.length, 0);
     });
 
@@ -177,29 +177,29 @@ describe.skip('Live Test', function () {
         const tenant1 = await this.warrant.Tenant.create({ tenantId: "tenant-1", name: "Tenant 1" });
         const tenant2 = await this.warrant.Tenant.create({ tenantId: "tenant-2", name: "Tenant 2" });
 
-        let user1Tenants = await this.warrant.Tenant.listTenantsForUser(user1.userId, { limit: 100 });
-        let tenant1Users = await this.warrant.User.listUsersForTenant("tenant-1", { limit: 100 });
+        let user1Tenants = await this.warrant.Tenant.listTenantsForUser(user1.userId, { limit: 100 }, { warrantToken: "latest" });
+        let tenant1Users = await this.warrant.User.listUsersForTenant("tenant-1", { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(user1Tenants.length, 0);
         assert.strictEqual(tenant1Users.length, 0);
 
         // Assign user1 -> tenant1
         await this.warrant.User.assignUserToTenant(tenant1.tenantId, user1.userId, "member");
 
-        user1Tenants = await this.warrant.Tenant.listTenantsForUser(user1.userId, { limit: 100 });
+        user1Tenants = await this.warrant.Tenant.listTenantsForUser(user1.userId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(user1Tenants.length, 1);
         assert.strictEqual(user1Tenants[0].tenantId, "tenant-1");
 
-        tenant1Users = await this.warrant.User.listUsersForTenant("tenant-1", { limit: 100 });
+        tenant1Users = await this.warrant.User.listUsersForTenant("tenant-1", { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(tenant1Users.length, 1);
         assert.strictEqual(tenant1Users[0].userId, user1.userId);
 
         // Remove user1 -> tenant1
         await this.warrant.User.removeUserFromTenant(tenant1.tenantId, user1.userId, "member");
 
-        user1Tenants = await this.warrant.Tenant.listTenantsForUser(user1.userId, { limit: 100 });
+        user1Tenants = await this.warrant.Tenant.listTenantsForUser(user1.userId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(user1Tenants.length, 0);
 
-        tenant1Users = await this.warrant.User.listUsersForTenant(tenant1.tenantId, { limit: 100 });
+        tenant1Users = await this.warrant.User.listUsersForTenant(tenant1.tenantId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(tenant1Users.length, 0);
 
         // Clean up
@@ -222,26 +222,26 @@ describe.skip('Live Test', function () {
         const createPermission = await this.warrant.Permission.create({ permissionId: "create-report", name: "Create Report", description: "Permission to create reports" });
         const viewPermission = await this.warrant.Permission.create({ permissionId: "view-report", name: "View Report", description: "Permission to view reports" });
 
-        let adminUserRoles = await this.warrant.Role.listRolesForUser(adminUser.userId, { limit: 100 });
-        let adminRolePermissions = await this.warrant.Permission.listPermissionsForRole(adminRole.roleId, { limit: 100 });
+        let adminUserRoles = await this.warrant.Role.listRolesForUser(adminUser.userId, { limit: 100 }, { warrantToken: "latest" });
+        let adminRolePermissions = await this.warrant.Permission.listPermissionsForRole(adminRole.roleId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(adminUserRoles.length, 0);
         assert.strictEqual(adminRolePermissions.length, 0);
 
-        let adminUserHasPermission = await this.warrant.Authorization.hasPermission({ permissionId: "create-report", subject: adminUser });
+        let adminUserHasPermission = await this.warrant.Authorization.hasPermission({ permissionId: "create-report", subject: adminUser }, { warrantToken: "latest" });
         assert.strictEqual(adminUserHasPermission, false);
 
         // Assign 'create-report' -> admin role -> admin user
         await this.warrant.Permission.assignPermissionToRole(adminRole.roleId, createPermission.permissionId);
         await this.warrant.Role.assignRoleToUser(adminUser.userId, adminRole.roleId);
 
-        adminUserHasPermission = await this.warrant.Authorization.hasPermission({ permissionId: "create-report", subject: adminUser });
+        adminUserHasPermission = await this.warrant.Authorization.hasPermission({ permissionId: "create-report", subject: adminUser }, { warrantToken: "latest" });
         assert.strictEqual(adminUserHasPermission, true);
 
-        adminUserRoles = await this.warrant.Role.listRolesForUser(adminUser.userId, { limit: 100 });
+        adminUserRoles = await this.warrant.Role.listRolesForUser(adminUser.userId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(adminUserRoles.length, 1);
         assert.strictEqual(adminUserRoles[0].roleId, adminRole.roleId);
 
-        adminRolePermissions = await this.warrant.Permission.listPermissionsForRole(adminRole.roleId, { limit: 100 });
+        adminRolePermissions = await this.warrant.Permission.listPermissionsForRole(adminRole.roleId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(adminRolePermissions.length, 1);
         assert.strictEqual(adminRolePermissions[0].permissionId, createPermission.permissionId)
 
@@ -251,34 +251,34 @@ describe.skip('Live Test', function () {
         adminUserHasPermission = await this.warrant.Authorization.hasPermission({ permissionId: "create-report", subject: adminUser });
         assert.strictEqual(adminUserHasPermission, false);
 
-        adminUserRoles = await this.warrant.Role.listRolesForUser(adminUser.userId, { limit: 100 });
+        adminUserRoles = await this.warrant.Role.listRolesForUser(adminUser.userId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(adminUserRoles.length, 0);
 
-        adminRolePermissions = await this.warrant.Permission.listPermissionsForRole(adminRole.roleId, { limit: 100 });
+        adminRolePermissions = await this.warrant.Permission.listPermissionsForRole(adminRole.roleId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(adminRolePermissions.length, 0);
 
         // Assign 'view-report' -> viewer user
         let viewerUserHasPermission = await this.warrant.Authorization.hasPermission({ permissionId: "view-report", subject: viewerUser });
         assert.strictEqual(viewerUserHasPermission, false);
 
-        let viewerUserPermissions = await this.warrant.Permission.listPermissionsForUser(viewerUser.userId, { limit: 100 });
+        let viewerUserPermissions = await this.warrant.Permission.listPermissionsForUser(viewerUser.userId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(viewerUserPermissions.length, 0);
 
         await this.warrant.Permission.assignPermissionToUser(viewerUser.userId, viewPermission.permissionId);
 
-        viewerUserHasPermission = await this.warrant.Authorization.hasPermission({ permissionId: "view-report", subject: viewerUser });
+        viewerUserHasPermission = await this.warrant.Authorization.hasPermission({ permissionId: "view-report", subject: viewerUser }, { warrantToken: "latest" });
         assert.strictEqual(viewerUserHasPermission, true);
 
-        viewerUserPermissions = await this.warrant.Permission.listPermissionsForUser(viewerUser.userId, { limit: 100 });
+        viewerUserPermissions = await this.warrant.Permission.listPermissionsForUser(viewerUser.userId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(viewerUserPermissions.length, 1);
         assert.strictEqual(viewerUserPermissions[0].permissionId, viewPermission.permissionId);
 
         await this.warrant.Permission.removePermissionFromUser(viewerUser.userId, viewPermission.permissionId);
 
-        viewerUserHasPermission = await this.warrant.Authorization.hasPermission({ permissionId: "view-report", subject: viewerUser });
+        viewerUserHasPermission = await this.warrant.Authorization.hasPermission({ permissionId: "view-report", subject: viewerUser }, { warrantToken: "latest" });
         assert.strictEqual(viewerUserHasPermission, false);
 
-        viewerUserPermissions = await this.warrant.Permission.listPermissionsForUser(viewerUser.userId, { limit: 100 });
+        viewerUserPermissions = await this.warrant.Permission.listPermissionsForUser(viewerUser.userId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(viewerUserPermissions.length, 0);
 
         // Clean up
@@ -305,63 +305,63 @@ describe.skip('Live Test', function () {
         const feature2 = await this.warrant.Feature.create({ featureId: "feature-2" });
 
         // Assign 'custom-feature' -> paid user
-        let paidUserHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "custom-feature", subject: paidUser });
+        let paidUserHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "custom-feature", subject: paidUser }, { warrantToken: "latest" });
         assert.strictEqual(paidUserHasFeature, false);
 
-        let paidUserFeatures = await this.warrant.Feature.listFeaturesForUser(paidUser.userId, { limit: 100 });
+        let paidUserFeatures = await this.warrant.Feature.listFeaturesForUser(paidUser.userId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(paidUserFeatures.length, 0);
 
         await this.warrant.Feature.assignFeatureToUser(paidUser.userId, customFeature.featureId);
 
-        paidUserHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "custom-feature", subject: paidUser });
+        paidUserHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "custom-feature", subject: paidUser }, { warrantToken: "latest" });
         assert.strictEqual(paidUserHasFeature, true);
 
-        paidUserFeatures = await this.warrant.Feature.listFeaturesForUser(paidUser.userId, { limit: 100 });
+        paidUserFeatures = await this.warrant.Feature.listFeaturesForUser(paidUser.userId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(paidUserFeatures.length, 1);
         assert.strictEqual(paidUserFeatures[0].featureId, "custom-feature");
 
         await this.warrant.Feature.removeFeatureFromUser(paidUser.userId, customFeature.featureId);
 
-        paidUserHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "custom-feature", subject: paidUser });
+        paidUserHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "custom-feature", subject: paidUser }, { warrantToken: "latest" });
         assert.strictEqual(paidUserHasFeature, false);
 
-        paidUserFeatures = await this.warrant.Feature.listFeaturesForUser(paidUser.userId, { limit: 100 });
+        paidUserFeatures = await this.warrant.Feature.listFeaturesForUser(paidUser.userId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(paidUserFeatures.length, 0);
 
         // Assign 'feature-1' -> 'free' tier -> free user
-        let freeUserHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "feature-1", subject: freeUser });
+        let freeUserHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "feature-1", subject: freeUser }, { warrantToken: "latest" });
         assert.strictEqual(freeUserHasFeature, false);
 
-        let freeTierFeatures = await this.warrant.Feature.listFeaturesForPricingTier(freeTier.pricingTierId, { limit: 100 });
+        let freeTierFeatures = await this.warrant.Feature.listFeaturesForPricingTier(freeTier.pricingTierId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(freeTierFeatures.length, 0);
 
-        let freeUserTiers = await this.warrant.PricingTier.listPricingTiersForUser(freeUser.userId, { limit: 100 });
+        let freeUserTiers = await this.warrant.PricingTier.listPricingTiersForUser(freeUser.userId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(freeUserTiers.length, 0);
 
         await this.warrant.Feature.assignFeatureToPricingTier(freeTier.pricingTierId, feature1.featureId);
         await this.warrant.PricingTier.assignPricingTierToUser(freeUser.userId, freeTier.pricingTierId);
 
-        freeUserHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "feature-1", subject: freeUser });
+        freeUserHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "feature-1", subject: freeUser }, { warrantToken: "latest" });
         assert.strictEqual(freeUserHasFeature, true);
 
-        freeTierFeatures = await this.warrant.Feature.listFeaturesForPricingTier(freeTier.pricingTierId, { limit: 100 });
+        freeTierFeatures = await this.warrant.Feature.listFeaturesForPricingTier(freeTier.pricingTierId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(freeTierFeatures.length, 1);
         assert.strictEqual(freeTierFeatures[0].featureId, "feature-1");
 
-        freeUserTiers = await this.warrant.PricingTier.listPricingTiersForUser(freeUser.userId, { limit: 100 });
+        freeUserTiers = await this.warrant.PricingTier.listPricingTiersForUser(freeUser.userId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(freeUserTiers.length, 1);
         assert.strictEqual(freeUserTiers[0].pricingTierId, "free");
 
         await this.warrant.Feature.removeFeatureFromPricingTier(freeTier.pricingTierId, feature1.featureId);
         await this.warrant.PricingTier.removePricingTierFromUser(freeUser.userId, freeTier.pricingTierId);
 
-        freeUserHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "feature-1", subject: freeUser });
+        freeUserHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "feature-1", subject: freeUser }, { warrantToken: "latest" });
         assert.strictEqual(freeUserHasFeature, false);
 
-        freeTierFeatures = await this.warrant.Feature.listFeaturesForPricingTier(freeTier.pricingTierId, { limit: 100 });
+        freeTierFeatures = await this.warrant.Feature.listFeaturesForPricingTier(freeTier.pricingTierId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(freeTierFeatures.length, 0);
 
-        freeUserTiers = await this.warrant.PricingTier.listPricingTiersForUser(freeUser.userId, { limit: 100 });
+        freeUserTiers = await this.warrant.PricingTier.listPricingTiersForUser(freeUser.userId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(freeUserTiers.length, 0);
 
         // Clean up
@@ -389,63 +389,63 @@ describe.skip('Live Test', function () {
         const feature2 = await this.warrant.Feature.create({ featureId: "feature-2" });
 
         // Assign 'custom-feature' -> paid tenant
-        let paidTenantHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "custom-feature", subject: paidTenant });
+        let paidTenantHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "custom-feature", subject: paidTenant }, { warrantToken: "latest" });
         assert.strictEqual(paidTenantHasFeature, false);
 
-        let paidTenantFeatures = await this.warrant.Feature.listFeaturesForTenant(paidTenant.tenantId, { limit: 100 });
+        let paidTenantFeatures = await this.warrant.Feature.listFeaturesForTenant(paidTenant.tenantId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(paidTenantFeatures.length, 0);
 
         await this.warrant.Feature.assignFeatureToTenant(paidTenant.tenantId, customFeature.featureId);
 
-        paidTenantHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "custom-feature", subject: paidTenant });
+        paidTenantHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "custom-feature", subject: paidTenant }, { warrantToken: "latest" });
         assert.strictEqual(paidTenantHasFeature, true);
 
-        paidTenantFeatures = await this.warrant.Feature.listFeaturesForTenant(paidTenant.tenantId, { limit: 100 });
+        paidTenantFeatures = await this.warrant.Feature.listFeaturesForTenant(paidTenant.tenantId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(paidTenantFeatures.length, 1);
         assert.strictEqual(paidTenantFeatures[0].featureId, "custom-feature");
 
         await this.warrant.Feature.removeFeatureFromTenant(paidTenant.tenantId, customFeature.featureId);
 
-        paidTenantHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "custom-feature", subject: paidTenant });
+        paidTenantHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "custom-feature", subject: paidTenant }, { warrantToken: "latest" });
         assert.strictEqual(paidTenantHasFeature, false);
 
-        paidTenantFeatures = await this.warrant.Feature.listFeaturesForTenant(paidTenant.tenantId, { limit: 100 });
+        paidTenantFeatures = await this.warrant.Feature.listFeaturesForTenant(paidTenant.tenantId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(paidTenantFeatures.length, 0);
 
         // Assign 'feature-1' -> 'free' tier -> free tenant
-        let freeTenantHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "feature-1", subject: freeTenant });
+        let freeTenantHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "feature-1", subject: freeTenant }, { warrantToken: "latest" });
         assert.strictEqual(freeTenantHasFeature, false);
 
-        let freeTierFeatures = await this.warrant.Feature.listFeaturesForPricingTier(freeTier.pricingTierId, { limit: 100 });
+        let freeTierFeatures = await this.warrant.Feature.listFeaturesForPricingTier(freeTier.pricingTierId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(freeTierFeatures.length, 0);
 
-        let freeTenantTiers = await this.warrant.PricingTier.listPricingTiersForTenant(freeTenant.tenantId, { limit: 100 });
+        let freeTenantTiers = await this.warrant.PricingTier.listPricingTiersForTenant(freeTenant.tenantId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(freeTenantTiers.length, 0);
 
         await this.warrant.Feature.assignFeatureToPricingTier(freeTier.pricingTierId, feature1.featureId);
         await this.warrant.PricingTier.assignPricingTierToTenant(freeTenant.tenantId, freeTier.pricingTierId);
 
-        freeTenantHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "feature-1", subject: freeTenant });
+        freeTenantHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "feature-1", subject: freeTenant }, { warrantToken: "latest" });
         assert.strictEqual(freeTenantHasFeature, true);
 
-        freeTierFeatures = await this.warrant.Feature.listFeaturesForPricingTier(freeTier.pricingTierId, { limit: 100 });
+        freeTierFeatures = await this.warrant.Feature.listFeaturesForPricingTier(freeTier.pricingTierId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(freeTierFeatures.length, 1);
         assert.strictEqual(freeTierFeatures[0].featureId, "feature-1");
 
-        freeTenantTiers = await this.warrant.PricingTier.listPricingTiersForTenant(freeTenant.tenantId, { limit: 100 });
+        freeTenantTiers = await this.warrant.PricingTier.listPricingTiersForTenant(freeTenant.tenantId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(freeTenantTiers.length, 1);
         assert.strictEqual(freeTenantTiers[0].pricingTierId, "free");
 
         await this.warrant.Feature.removeFeatureFromPricingTier(freeTier.pricingTierId, feature1.featureId);
         await this.warrant.PricingTier.removePricingTierFromTenant(freeTenant.tenantId, freeTier.pricingTierId);
 
-        freeTenantHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "feature-1", subject: freeTenant });
+        freeTenantHasFeature = await this.warrant.Authorization.hasFeature({ featureId: "feature-1", subject: freeTenant }, { warrantToken: "latest" });
         assert.strictEqual(freeTenantHasFeature, false);
 
-        freeTierFeatures = await this.warrant.Feature.listFeaturesForPricingTier(freeTier.pricingTierId, { limit: 100 });
+        freeTierFeatures = await this.warrant.Feature.listFeaturesForPricingTier(freeTier.pricingTierId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(freeTierFeatures.length, 0);
 
-        freeTenantTiers = await this.warrant.PricingTier.listPricingTiersForTenant(freeTenant.tenantId, { limit: 100 });
+        freeTenantTiers = await this.warrant.PricingTier.listPricingTiersForTenant(freeTenant.tenantId, { limit: 100 }, { warrantToken: "latest" });
         assert.strictEqual(freeTenantTiers.length, 0);
 
         // Clean up
@@ -486,6 +486,8 @@ describe.skip('Live Test', function () {
             object: newPermission,
             relation: "member",
             subject: newUser
+        }, {
+            warrantToken: "latest"
         });
         assert.strictEqual(userHasPermission, false);
 
@@ -499,6 +501,8 @@ describe.skip('Live Test', function () {
             object: newPermission,
             relation: "member",
             subject: newUser
+        }, {
+            warrantToken: "latest"
         });
         assert.strictEqual(userHasPermission, true);
 
@@ -530,6 +534,8 @@ describe.skip('Live Test', function () {
             object: newPermission,
             relation: "member",
             subject: newUser
+        }, {
+            warrantToken: "latest"
         });
         assert.strictEqual(userHasPermission, false);
 
@@ -537,7 +543,7 @@ describe.skip('Live Test', function () {
         await this.warrant.Permission.delete(newPermission.permissionId);
     });
 
-    it('warrant with policy', async function() {
+    it.only('warrant with policy', async function() {
         await this.warrant.Warrant.create({
             object: {
                 objectType: "permission",
@@ -564,6 +570,8 @@ describe.skip('Live Test', function () {
             context: {
                 "geo": "us",
             }
+        }, {
+            warrantToken: "latest"
         });
         assert.strictEqual(checkResult, true);
 
@@ -580,6 +588,8 @@ describe.skip('Live Test', function () {
             context: {
                 "geo": "eu",
             }
+        }, {
+            warrantToken: "latest"
         });
         assert.strictEqual(checkResult, false);
 


### PR DESCRIPTION
This PR adds support for the `Warrant-Token` header for read requests, check, and query. By passing `latest` in with the `Warrant-Token` header, this allows for consistent reads. This fixes an issue where changes not be reflected in a read if it is made immediately after a write is made for the same object. More broadly, this PR adds support for configuration on a per-request basis as more options are required.